### PR TITLE
Clone, Display derives + PitchClass::into_u8

### DIFF
--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -4,7 +4,7 @@ use crate::chord::{Number, Quality};
 use crate::interval::Interval;
 use crate::note::{Note, Notes, PitchClass};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chord {
     pub root: PitchClass,
     pub octave: u8,

--- a/src/chord/number.rs
+++ b/src/chord/number.rs
@@ -1,5 +1,6 @@
 use crate::chord::errors::ChordError;
 use regex::{Match, Regex};
+use strum_macros::Display;
 
 const REGEX_NUMBER_TRIAD: &str = "(?i)(triad)";
 const REGEX_NUMBER_SEVENTH: &str = "(?i)(seventh)";
@@ -8,7 +9,7 @@ const REGEX_NUMBER_NINTH: &str = "(?i)(ninth)";
 const REGEX_NUMBER_ELEVENTH: &str = "(?i)(eleventh)";
 const REGEX_NUMBER_THIRTEENTH: &str = "(?i)(thirteenth)";
 
-#[derive(Debug, PartialEq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq)]
 pub enum Number {
     Triad,
     Seventh,

--- a/src/chord/quality.rs
+++ b/src/chord/quality.rs
@@ -1,5 +1,6 @@
 use crate::chord::errors::ChordError;
 use regex::{Match, Regex};
+use strum_macros::Display;
 
 const REGEX_QUALITY_MAJOR: &str = r"^(M\s+|M$|(?i)maj|Maj|Major|major)";
 const REGEX_QUALITY_MINOR: &str = r"^(m\s+|m$|(?i)min|Min|Minor|minor)";
@@ -10,7 +11,7 @@ const REGEX_QUALITY_DOMINANT: &str = r"(?i)^(dominant)";
 const REGEX_QUALITY_SUSPENDED_4: &str = r"(?i)^(sus4\s+|sus4$|suspended4)";
 const REGEX_QUALITY_SUSPENDED_2: &str = r"(?i)^(sus2\s+|sus2$|suspended2)";
 
-#[derive(Debug, PartialEq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq)]
 pub enum Quality {
     Major,
     Minor,

--- a/src/note/note.rs
+++ b/src/note/note.rs
@@ -2,7 +2,7 @@ use crate::note::PitchClass;
 use std::fmt;
 use std::fmt::Formatter;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Note {
     pub pitch_class: PitchClass,
     pub octave: u8,

--- a/src/note/pitch_class.rs
+++ b/src/note/pitch_class.rs
@@ -101,6 +101,24 @@ impl PitchClass {
 
         Ok((pitch_class, pitch_match))
     }
+
+    pub fn into_u8(self) -> u8 {
+        use PitchClass::*;
+        match self {
+            C => 0,
+            Cs => 1,
+            D => 2,
+            Ds => 3,
+            E => 4,
+            F => 5,
+            Fs => 6,
+            G => 7,
+            Gs => 8,
+            A => 9,
+            As => 10,
+            B => 11,
+        }
+    }
 }
 
 impl fmt::Display for PitchClass {

--- a/src/scale/errors.rs
+++ b/src/scale/errors.rs
@@ -3,7 +3,7 @@ use crate::note::NoteError;
 use std::error;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ScaleError {
     InvalidInterval,
     ModeFromRegex,

--- a/src/scale/mode.rs
+++ b/src/scale/mode.rs
@@ -14,7 +14,7 @@ const REGEX_LOCRIAN: &str = r"(?i)^(locrian)";
 const REGEX_MELODIC_MINOR: &str = r"(?i)(mel minor|melodicminor|melodic\s+minor)";
 const REGEX_HARMONIC_MINOR: &str = r"(?i)(har minor|harmonicminor|harmonic\s+minor)";
 
-#[derive(Debug, EnumIter, Display, PartialEq)]
+#[derive(Display, Debug, Clone, Copy, EnumIter, PartialEq)]
 pub enum Mode {
     Ionian,
     Dorian,

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -2,14 +2,15 @@ use crate::interval::Interval;
 use crate::note::{Note, Notes, PitchClass};
 use crate::scale::errors::ScaleError;
 use crate::scale::{Mode, ScaleType};
+use strum_macros::Display;
 
-#[derive(Debug)]
+#[derive(Display, Debug, Clone, Copy)]
 pub enum Direction {
     Ascending,
     Descending,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Scale {
     pub tonic: PitchClass,
     pub octave: u8,

--- a/src/scale/scale_type.rs
+++ b/src/scale/scale_type.rs
@@ -1,7 +1,7 @@
 use crate::scale::{Mode, Mode::*};
 use strum_macros::{Display, EnumIter};
 
-#[derive(Display, Debug, EnumIter, PartialEq)]
+#[derive(Display, Debug, Clone, EnumIter, PartialEq)]
 pub enum ScaleType {
     Diatonic,
     MelodicMinor,


### PR DESCRIPTION
Added some missing Clone and Displays derives for easier library usage. Needed to clone `Note`s myself and added the other ones for completion. 

Also added `PitchClass::into_u8` for cases when you need the number representation, in my case for calculating the MIDI note number.