### PR TITLE
`PitchClass::into_u8` test and correcter(?) `PitchClass::from_str` behaviour

### DIFF
--- a/src/note/pitch_class.rs
+++ b/src/note/pitch_class.rs
@@ -55,7 +55,7 @@ impl PitchClass {
             'G' | 'g' => G,
             'A' | 'a' => A,
             'B' | 'b' => B,
-            _ => C,
+            _ => return None,
         };
 
         if characters.len() > 1 {

--- a/tests/note/test_pitch_class.rs
+++ b/tests/note/test_pitch_class.rs
@@ -37,4 +37,27 @@ mod test_note {
             assert_eq!(p, pitch_class);
         }
     }
+
+    #[test]
+    fn test_pitch_class_into_u8() {
+        let table = vec![
+            (C, 0),
+            (Cs, 1),
+            (D, 2),
+            (Ds, 3),
+            (E, 4),
+            (F, 5),
+            (Fs, 6),
+            (G, 7),
+            (Gs, 8),
+            (A, 9),
+            (As, 10),
+            (B, 11),
+        ];
+
+        for (pitch_class, number) in table {
+            let n = pitch_class.into_u8();
+            assert_eq!(n, number);
+        }
+    }
 }


### PR DESCRIPTION
I added the test for the method I added and made a small change, so a "wrong" character won't become a C.