### PR TITLE
Fixes off by one error in excess octave calculation

### DIFF
--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -163,7 +163,7 @@ impl Interval {
     pub fn second_note_from(self, first_note: Note) -> Note {
         let pitch_class = PitchClass::from_interval(first_note.pitch_class, self);
         let octave = first_note.octave;
-        let excess_octave = (first_note.pitch_class as u8 + self.semitone_count - 1) / 12;
+        let excess_octave = (first_note.pitch_class as u8 + self.semitone_count) / 12;
 
         Note {
             octave: octave + excess_octave,


### PR DESCRIPTION
tldr:
```rust
let scale = Scale::new(
    ScaleType::Diatonic,
    PitchClass::G,
    5,
    Some(Mode::Mixolydian)
).unwrap();

scale
    .notes()
    .iter()
```

Before: 
<img src="https://user-images.githubusercontent.com/3784017/86029601-8ee02300-ba5d-11ea-9c9d-7cb2ed093407.png" width="50%" height="50%">
```
Note { pitch_class: G, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: A, octave: 5 } (0)
Note { pitch_class: A, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: B, octave: 5 } (0)
Note { pitch_class: B, octave: 5 } + Interval { semitone_count: 1, quality: Minor, number: Second, step: Some(Half) } = Note { pitch_class: C, octave: 5 } (0)
Note { pitch_class: C, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: D, octave: 5 } (0)
Note { pitch_class: D, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: E, octave: 5 } (0)
Note { pitch_class: E, octave: 5 } + Interval { semitone_count: 1, quality: Minor, number: Second, step: Some(Half) } = Note { pitch_class: F, octave: 5 } (0)
Note { pitch_class: F, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: G, octave: 5 } (0)
```

After:
<img src="https://user-images.githubusercontent.com/3784017/86029605-90115000-ba5d-11ea-8e81-87f0bb8be01b.png" width="50%" height="50%">

```
Note { pitch_class: G, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: A, octave: 5 } (0)
Note { pitch_class: A, octave: 5 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: B, octave: 5 } (0)
Note { pitch_class: B, octave: 5 } + Interval { semitone_count: 1, quality: Minor, number: Second, step: Some(Half) } = Note { pitch_class: C, octave: 6 } (1)
Note { pitch_class: C, octave: 6 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: D, octave: 6 } (0)
Note { pitch_class: D, octave: 6 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: E, octave: 6 } (0)
Note { pitch_class: E, octave: 6 } + Interval { semitone_count: 1, quality: Minor, number: Second, step: Some(Half) } = Note { pitch_class: F, octave: 6 } (0)
Note { pitch_class: F, octave: 6 } + Interval { semitone_count: 2, quality: Major, number: Second, step: Some(Whole) } = Note { pitch_class: G, octave: 6 } (0)
```