### PR TITLE
Add test of octave increment in scale generation

### DIFF
--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -68,4 +68,18 @@ mod scale_tests {
             }
         }
     }
+
+    #[test]
+    fn test_octave_increment() {
+        let scale = Scale::new(
+            ScaleType::Diatonic,
+            PitchClass::G,
+            5,
+            Some(Mode::Mixolydian)
+        ).unwrap();
+
+        for (i, note) in scale.notes().iter().enumerate() {
+            assert_eq!(note.octave, if i <= 2 { 5 } else { 6 });
+        }
+    }
 }


### PR DESCRIPTION
Supplements #13 

- Adds test `test_octave_increment` to `test_scales.rs`
    - Tests that the `octave` field increases at the right note (C6 as 4th note of G Mixolydian)
    - Depends on `second_note_from` and verifies scale generation
    - **Intended to test #13** -- It will fail until that is merged

Hi! I discovered this repo and found a dangling PR, so here's the test requested by @ozankasikci. Very nice and intuitive project, by the way!

Edit: If your checks are blocking the merge, then just message me when #13 is merged. I can then rebase on master, and then the checks will rerun successfully.