### PR TITLE
Change encoding of pitch classes

### DIFF
--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -2,7 +2,7 @@ use crate::chord::errors::ChordError;
 use crate::chord::number::Number::Triad;
 use crate::chord::{Number, Quality};
 use crate::interval::Interval;
-use crate::note::{Note, Notes, PitchClass, PitchSymbol};
+use crate::note::{Note, Notes, PitchClass, PitchSymbol, pclass};
 
 /// A chord.
 #[derive(Debug, Clone)]
@@ -95,7 +95,7 @@ impl Notes for Chord {
 impl Default for Chord {
     fn default() -> Self {
         Chord {
-            root: PitchClass { symbol: PitchSymbol::C, accidental: 0 },
+            root: pclass(PitchSymbol::C,0),
             octave: 4,
             intervals: vec![],
             quality: Quality::Major,

--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -2,7 +2,7 @@ use crate::chord::errors::ChordError;
 use crate::chord::number::Number::Triad;
 use crate::chord::{Number, Quality};
 use crate::interval::Interval;
-use crate::note::{Note, Notes, PitchClass};
+use crate::note::{Note, Notes, PitchClass, PitchSymbol};
 
 /// A chord.
 #[derive(Debug, Clone)]
@@ -95,7 +95,7 @@ impl Notes for Chord {
 impl Default for Chord {
     fn default() -> Self {
         Chord {
-            root: PitchClass::C,
+            root: PitchClass { symbol: PitchSymbol::C, accidental: 0 },
             octave: 4,
             intervals: vec![],
             quality: Quality::Major,

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -163,7 +163,7 @@ impl Interval {
     pub fn second_note_from(self, first_note: Note) -> Note {
         let pitch_class = PitchClass::from_interval(first_note.pitch_class, self);
         let octave = first_note.octave;
-        let excess_octave = (first_note.pitch_class as u8 + self.semitone_count) / 12;
+        let excess_octave = (first_note.pitch_class.into_u8() + self.semitone_count) / 12;
 
         Note {
             octave: octave + excess_octave,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,18 +14,18 @@
 //!
 //! ```no_run
 //! extern crate rust_music_theory as rustmt;
-//! use rustmt::note::{Note, Notes, PitchClass};
+//! use rustmt::note::{Note, Notes, PitchClass, PitchSymbol::*, pclass};
 //! use rustmt::scale::{Scale, ScaleType, Mode};
 //! use rustmt::chord::{Chord, Number as ChordNumber, Quality as ChordQuality};
 //!
 //! // to create a Note, specify a pitch class and an octave;
-//! let note = Note::new(PitchClass::As, 4);
-//! // Note { pitch_class: A, octave: 4 }
+//! let note = Note::new(pclass(A,1), 4);
+//! // Note { pclass(A,1), octave: 4 }
 //!
 //! // Scale Example;
 //! let scale = Scale::new(
 //!     ScaleType::Diatonic,    // scale type
-//!     PitchClass::C,          // tonic
+//!     pclass(C,0),            // tonic
 //!     4,                      // octave
 //!     Some(Mode::Ionian),     // scale mode
 //! ).unwrap();
@@ -34,7 +34,7 @@
 //! let scale_notes = scale.notes();
 //!
 //! // Chord Example;
-//! let chord = Chord::new(PitchClass::C, ChordQuality::Major, ChordNumber::Triad);
+//! let chord = Chord::new(pclass(C,0), ChordQuality::Major, ChordNumber::Triad);
 //!
 //! // returns a Vector of the Notes of the chord
 //! let chord_notes = chord.notes();

--- a/src/note.rs
+++ b/src/note.rs
@@ -6,4 +6,4 @@ mod pitch_class;
 
 pub use errors::NoteError;
 pub use note::{Note, Notes};
-pub use pitch_class::PitchClass;
+pub use pitch_class::{PitchClass, PitchSymbol, pclass};

--- a/src/note/pitch_class.rs
+++ b/src/note/pitch_class.rs
@@ -129,15 +129,18 @@ impl PitchClass {
 impl fmt::Display for PitchClass {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use PitchSymbol::*;
-        match self.symbol {
-            C => write!(fmt, "C"),
-            D => write!(fmt, "D"),
-            E => write!(fmt, "E"),
-            F => write!(fmt, "F"),
-            G => write!(fmt, "G"),
-            A => write!(fmt, "A"),
-            B => write!(fmt, "B"),
-        }
+        let sym = match self.symbol {
+            C => "C",
+            D => "D",
+            E => "E",
+            F => "F",
+            G => "G",
+            A => "A",
+            B => "B",
+        };
+
+        let flat = if self.accidental < 0 { "b" } else { "#" };
+        write!(fmt, "{}", sym.to_owned() + &(0..self.accidental.abs()).map(|_| flat).collect::<String>())
     }
 }
 

--- a/src/note/pitch_class.rs
+++ b/src/note/pitch_class.rs
@@ -12,15 +12,7 @@ lazy_static! {
 
 /// A pitch class (A, B, C#, etc).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter)]
-pub enum PitchSymbol {
-    C,
-    D,
-    E,
-    F,
-    G,
-    A,
-    B,
-}
+pub enum PitchSymbol { C, D, E, F, G, A, B }
 
 pub fn pclass(symbol: PitchSymbol, accidental: i8) -> PitchClass {
     PitchClass { symbol, accidental }
@@ -139,8 +131,8 @@ impl fmt::Display for PitchClass {
             B => "B",
         };
 
-        let flat = if self.accidental < 0 { "b" } else { "#" };
-        write!(fmt, "{}", sym.to_owned() + &(0..self.accidental.abs()).map(|_| flat).collect::<String>())
+        let acc = if self.accidental < 0 { "b" } else { "#" };
+        write!(fmt, "{}", sym.to_owned() + &(0..self.accidental.abs()).map(|_| acc).collect::<String>())
     }
 }
 

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -1,5 +1,5 @@
 use crate::interval::Interval;
-use crate::note::{Note, Notes, PitchClass, PitchSymbol};
+use crate::note::{Note, Notes, PitchClass, PitchSymbol, pclass};
 use crate::scale::errors::ScaleError;
 use crate::scale::{Mode, ScaleType};
 use strum_macros::Display;
@@ -98,7 +98,7 @@ impl Notes for Scale {
 impl Default for Scale {
     fn default() -> Self {
         Scale {
-            tonic: PitchClass { symbol: PitchSymbol::C, accidental: 0 },
+            tonic: pclass(PitchSymbol::C, 0),
             octave: 0,
             scale_type: ScaleType::Diatonic,
             mode: Some(Mode::Ionian),

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -1,5 +1,5 @@
 use crate::interval::Interval;
-use crate::note::{Note, Notes, PitchClass};
+use crate::note::{Note, Notes, PitchClass, PitchSymbol};
 use crate::scale::errors::ScaleError;
 use crate::scale::{Mode, ScaleType};
 use strum_macros::Display;
@@ -98,7 +98,7 @@ impl Notes for Scale {
 impl Default for Scale {
     fn default() -> Self {
         Scale {
-            tonic: PitchClass::C,
+            tonic: PitchClass { symbol: PitchSymbol::C, accidental: 0 },
             octave: 0,
             scale_type: ScaleType::Diatonic,
             mode: Some(Mode::Ionian),

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 use theory::chord::{Number::*, Quality::*, *};
-use theory::note::{PitchClass::*, *};
+use theory::note::{PitchSymbol::*, *};
 
 fn assert_notes(pitches: &[PitchClass], notes: Vec<Note>) {
     for (i, pitch) in pitches.iter().enumerate() {
@@ -15,18 +15,18 @@ mod chord_tests {
     #[test]
     fn test_all_chords_in_c() {
         let chord_tuples = [
-            (Chord::new(C, Major, Triad), vec![C, E, G]),
-            (Chord::new(C, Minor, Triad), vec![C, Ds, G]),
-            (Chord::new(C, Augmented, Triad), vec![C, E, Gs]),
-            (Chord::new(C, Diminished, Triad), vec![C, Ds, Fs]),
-            (Chord::new(C, Major, Seventh), vec![C, E, G, B]),
-            (Chord::new(C, Minor, Seventh), vec![C, Ds, G, As]),
-            (Chord::new(C, Augmented, Seventh), vec![C, E, Gs, As]),
-            (Chord::new(C, Augmented, MajorSeventh), vec![C, E, Gs, B]),
-            (Chord::new(C, Diminished, Seventh), vec![C, Ds, Fs, A]),
-            (Chord::new(C, HalfDiminished, Seventh), vec![C, Ds, Fs, As]),
-            (Chord::new(C, Minor, MajorSeventh), vec![C, Ds, G, B]),
-            (Chord::new(C, Dominant, Seventh), vec![C, E, G, As]),
+            (Chord::new(pclass(C,0), Major, Triad), vec![pclass(C,0), pclass(E,0), pclass(G,0)]),
+            (Chord::new(pclass(C,0), Minor, Triad), vec![pclass(C,0), pclass(D,1), pclass(G,0)]),
+            (Chord::new(pclass(C,0), Augmented, Triad), vec![pclass(C,0), pclass(E,0), pclass(G,1)]),
+            (Chord::new(pclass(C,0), Diminished, Triad), vec![pclass(C,0), pclass(D,1), pclass(F,1)]),
+            (Chord::new(pclass(C,0), Major, Seventh), vec![pclass(C,0), pclass(E,0), pclass(G,0), pclass(B,0)]),
+            (Chord::new(pclass(C,0), Minor, Seventh), vec![pclass(C,0), pclass(D,1), pclass(G,0), pclass(A,1)]),
+            (Chord::new(pclass(C,0), Augmented, Seventh), vec![pclass(C,0), pclass(E,0), pclass(G,1), pclass(A,1)]),
+            (Chord::new(pclass(C,0), Augmented, MajorSeventh), vec![pclass(C,0), pclass(E,0), pclass(G,1), pclass(B,0)]),
+            (Chord::new(pclass(C,0), Diminished, Seventh), vec![pclass(C,0), pclass(D,1), pclass(F,1), pclass(A,0)]),
+            (Chord::new(pclass(C,0), HalfDiminished, Seventh), vec![pclass(C,0), pclass(D,1), pclass(F,1), pclass(A,1)]),
+            (Chord::new(pclass(C,0), Minor, MajorSeventh), vec![pclass(C,0), pclass(D,1), pclass(G,0), pclass(B,0)]),
+            (Chord::new(pclass(C,0), Dominant, Seventh), vec![pclass(C,0), pclass(E,0), pclass(G,0), pclass(A,1)]),
         ];
 
         for chord_tuple in chord_tuples.iter() {

--- a/tests/chord/test_regex.rs
+++ b/tests/chord/test_regex.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 use theory::chord::{Chord, Number, Number::*, Quality, Quality::*};
-use theory::note::{PitchClass, PitchClass::*};
+use theory::note::{PitchClass, PitchSymbol::*, pclass};
 
 fn assert_chords(table: Vec<(&str, PitchClass, Quality, Number)>) {
     for (string, pitch, quality, number) in table {
@@ -18,17 +18,17 @@ mod chord_regex_tests {
     #[test]
     fn test_major() {
         let table = vec![
-            ("C Major", C, Major, Triad),
-            ("E MAJOR", E, Major, Triad),
-            ("C Maj", C, Major, Triad),
-            ("Cb MAJ", B, Major, Triad),
-            ("Cb MAJ Seventh", B, Major, Seventh),
-            ("C M", C, Major, Triad),
-            ("C MaJ Triad", C, Major, Triad),
-            ("C Major Seventh", C, Major, Seventh),
-            ("C M Ninth", C, Major, Ninth),
-            ("C M eleventh", C, Major, Eleventh),
-            ("C M ThirTeenth", C, Major, Thirteenth),
+            ("C Major", pclass(C,0), Major, Triad),
+            ("E MAJOR", pclass(E,0), Major, Triad),
+            ("C Maj", pclass(C,0), Major, Triad),
+            ("Cb MAJ", pclass(C,-1), Major, Triad),
+            ("Cb MAJ Seventh", pclass(C,-1), Major, Seventh),
+            ("C M", pclass(C,0), Major, Triad),
+            ("C MaJ Triad", pclass(C,0), Major, Triad),
+            ("C Major Seventh", pclass(C,0), Major, Seventh),
+            ("C M Ninth", pclass(C,0), Major, Ninth),
+            ("C M eleventh", pclass(C,0), Major, Eleventh),
+            ("C M ThirTeenth", pclass(C,0), Major, Thirteenth),
         ];
 
         assert_chords(table);
@@ -37,17 +37,17 @@ mod chord_regex_tests {
     #[test]
     fn test_minor() {
         let table = vec![
-            ("C Minor", C, Minor, Triad),
-            ("E MINOR", E, Minor, Triad),
-            ("C Min", C, Minor, Triad),
-            ("Cb MIN", B, Minor, Triad),
-            ("Cb MIN Seventh", B, Minor, Seventh),
-            ("C m", C, Minor, Triad),
-            ("C MiN Triad", C, Minor, Triad),
-            ("C Minor Seventh", C, Minor, Seventh),
-            ("C m Ninth", C, Minor, Ninth),
-            ("C#m Eleventh", Cs, Minor, Eleventh),
-            ("Dsm Thirteenth", Ds, Minor, Thirteenth),
+            ("C Minor", pclass(C,0), Minor, Triad),
+            ("E MINOR", pclass(E,0), Minor, Triad),
+            ("C Min", pclass(C,0), Minor, Triad),
+            ("Cb MIN", pclass(C,-1), Minor, Triad),
+            ("Cb MIN Seventh", pclass(C,-1), Minor, Seventh),
+            ("C m", pclass(C,0), Minor, Triad),
+            ("C MiN Triad", pclass(C,0), Minor, Triad),
+            ("C Minor Seventh", pclass(C,0), Minor, Seventh),
+            ("C m Ninth", pclass(C,0), Minor, Ninth),
+            ("C#m Eleventh", pclass(C,1), Minor, Eleventh),
+            ("Dsm Thirteenth", pclass(D,1), Minor, Thirteenth),
         ];
 
         assert_chords(table);
@@ -56,17 +56,17 @@ mod chord_regex_tests {
     #[test]
     fn test_augmented() {
         let table = vec![
-            ("C augmented", C, Augmented, Triad),
-            ("E Augmented", E, Augmented, Triad),
-            ("C augmented", C, Augmented, Triad),
-            ("Cb augmented", B, Augmented, Triad),
-            ("Cb augmented seventh", B, Augmented, Seventh),
-            ("C augmented", C, Augmented, Triad),
-            ("C augmented Triad", C, Augmented, Triad),
-            ("C Augmented Seventh", C, Augmented, Seventh),
-            ("C Augmented Ninth", C, Augmented, Ninth),
-            ("C# augmented Eleventh", Cs, Augmented, Eleventh),
-            ("Ds augmented Thirteenth", Ds, Augmented, Thirteenth),
+            ("C augmented", pclass(C,0), Augmented, Triad),
+            ("E Augmented", pclass(E,0), Augmented, Triad),
+            ("C augmented", pclass(C,0), Augmented, Triad),
+            ("Cb augmented", pclass(C,-1), Augmented, Triad),
+            ("Cb augmented seventh", pclass(C,-1), Augmented, Seventh),
+            ("C augmented", pclass(C,0), Augmented, Triad),
+            ("C augmented Triad", pclass(C,0), Augmented, Triad),
+            ("C Augmented Seventh", pclass(C,0), Augmented, Seventh),
+            ("C Augmented Ninth", pclass(C,0), Augmented, Ninth),
+            ("C# augmented Eleventh", pclass(C,1), Augmented, Eleventh),
+            ("Ds augmented Thirteenth", pclass(D,1), Augmented, Thirteenth),
         ];
 
         assert_chords(table);
@@ -75,17 +75,17 @@ mod chord_regex_tests {
     #[test]
     fn test_diminished() {
         let table = vec![
-            ("C Diminished", C, Diminished, Triad),
-            ("E Diminished", E, Diminished, Triad),
-            ("C Diminished", C, Diminished, Triad),
-            ("Cb Diminished", B, Diminished, Triad),
-            ("Cb Diminished seventh", B, Diminished, Seventh),
-            ("C Diminished", C, Diminished, Triad),
-            ("C Diminished Triad", C, Diminished, Triad),
-            ("C Diminished Seventh", C, Diminished, Seventh),
-            ("C Diminished Ninth", C, Diminished, Ninth),
-            ("C# Diminished Eleventh", Cs, Diminished, Eleventh),
-            ("Ds Diminished Thirteenth", Ds, Diminished, Thirteenth),
+            ("C Diminished", pclass(C,0), Diminished, Triad),
+            ("E Diminished", pclass(E,0), Diminished, Triad),
+            ("C Diminished", pclass(C,0), Diminished, Triad),
+            ("Cb Diminished", pclass(C,-1), Diminished, Triad),
+            ("Cb Diminished seventh", pclass(C,-1), Diminished, Seventh),
+            ("C Diminished", pclass(C,0), Diminished, Triad),
+            ("C Diminished Triad", pclass(C,0), Diminished, Triad),
+            ("C Diminished Seventh", pclass(C,0), Diminished, Seventh),
+            ("C Diminished Ninth", pclass(C,0), Diminished, Ninth),
+            ("C# Diminished Eleventh", pclass(C,1), Diminished, Eleventh),
+            ("Ds Diminished Thirteenth", pclass(D,1), Diminished, Thirteenth),
         ];
 
         assert_chords(table);
@@ -94,19 +94,19 @@ mod chord_regex_tests {
     #[test]
     fn test_half_diminished() {
         let table = vec![
-            ("C Half Diminished", C, HalfDiminished, Triad),
-            ("E halfdiminished", E, HalfDiminished, Triad),
-            ("C half diminished", C, HalfDiminished, Triad),
-            ("Cb HALFDIMINISHED", B, HalfDiminished, Triad),
-            ("Cb HalfDiminished seventh", B, HalfDiminished, Seventh),
-            ("C HalfDiminished", C, HalfDiminished, Triad),
-            ("C HalfDiminished Triad", C, HalfDiminished, Triad),
-            ("C HalfDiminished Seventh", C, HalfDiminished, Seventh),
-            ("C HalfDiminished Ninth", C, HalfDiminished, Ninth),
-            ("C# HalfDiminished Eleventh", Cs, HalfDiminished, Eleventh),
+            ("C Half Diminished", pclass(C,0), HalfDiminished, Triad),
+            ("E halfdiminished", pclass(E,0), HalfDiminished, Triad),
+            ("C half diminished", pclass(C,0), HalfDiminished, Triad),
+            ("Cb HALFDIMINISHED", pclass(C,-1), HalfDiminished, Triad),
+            ("Cb HalfDiminished seventh", pclass(C,-1), HalfDiminished, Seventh),
+            ("C HalfDiminished", pclass(C,0), HalfDiminished, Triad),
+            ("C HalfDiminished Triad", pclass(C,0), HalfDiminished, Triad),
+            ("C HalfDiminished Seventh", pclass(C,0), HalfDiminished, Seventh),
+            ("C HalfDiminished Ninth", pclass(C,0), HalfDiminished, Ninth),
+            ("C# HalfDiminished Eleventh", pclass(C,1), HalfDiminished, Eleventh),
             (
                 "Ds HalfDiminished Thirteenth",
-                Ds,
+                pclass(D,1),
                 HalfDiminished,
                 Thirteenth,
             ),
@@ -118,17 +118,17 @@ mod chord_regex_tests {
     #[test]
     fn test_dominant() {
         let table = vec![
-            ("C dominant", C, Dominant, Triad),
-            ("E DOMINANT", E, Dominant, Triad),
-            ("C DOmInAnT", C, Dominant, Triad),
-            ("Cb Dominant", B, Dominant, Triad),
-            ("Cb Dominant seventh", B, Dominant, Seventh),
-            ("C Dominant", C, Dominant, Triad),
-            ("C Dominant Triad", C, Dominant, Triad),
-            ("C Dominant Seventh", C, Dominant, Seventh),
-            ("C Dominant Ninth", C, Dominant, Ninth),
-            ("C# Dominant Eleventh", Cs, Dominant, Eleventh),
-            ("Ds Dominant Thirteenth", Ds, Dominant, Thirteenth),
+            ("C dominant", pclass(C,0), Dominant, Triad),
+            ("E DOMINANT", pclass(E,0), Dominant, Triad),
+            ("C DOmInAnT", pclass(C,0), Dominant, Triad),
+            ("Cb Dominant", pclass(C,-1), Dominant, Triad),
+            ("Cb Dominant seventh", pclass(C,-1), Dominant, Seventh),
+            ("C Dominant", pclass(C,0), Dominant, Triad),
+            ("C Dominant Triad", pclass(C,0), Dominant, Triad),
+            ("C Dominant Seventh", pclass(C,0), Dominant, Seventh),
+            ("C Dominant Ninth", pclass(C,0), Dominant, Ninth),
+            ("C# Dominant Eleventh", pclass(C,1), Dominant, Eleventh),
+            ("Ds Dominant Thirteenth", pclass(D,1), Dominant, Thirteenth),
         ];
 
         assert_chords(table);
@@ -137,11 +137,11 @@ mod chord_regex_tests {
     #[test]
     fn test_suspended() {
         let table = vec![
-            ("C sus2", C, Suspended2, Triad),
-            ("E sus2 triad", E, Suspended2, Triad),
-            ("C sus4", C, Suspended4, Triad),
-            ("Cb suspended4", B, Suspended4, Triad),
-            ("Cb suspended2", B, Suspended2, Triad),
+            ("C sus2", pclass(C,0), Suspended2, Triad),
+            ("E sus2 triad", pclass(E,0), Suspended2, Triad),
+            ("C sus4", pclass(C,0), Suspended4, Triad),
+            ("Cb suspended4", pclass(C,-1), Suspended4, Triad),
+            ("Cb suspended2", pclass(C,-1), Suspended2, Triad),
         ];
 
         assert_chords(table);

--- a/tests/note/test_pitch_class.rs
+++ b/tests/note/test_pitch_class.rs
@@ -60,4 +60,11 @@ mod test_note {
             assert_eq!(n, number);
         }
     }
+
+    #[test]
+    fn test_pitch_class_format() {
+        assert_eq!(format!("{}", pclass(C,2)), "C##");
+        assert_eq!(format!("{}", pclass(C,-2)), "Cbb");
+        assert_eq!(format!("{}", pclass(C,0)), "C");
+    }
 }

--- a/tests/note/test_pitch_class.rs
+++ b/tests/note/test_pitch_class.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::{PitchClass, PitchClass::*};
+use theory::note::{PitchClass, PitchSymbol::*, pclass};
 
 #[cfg(test)]
 mod test_note {
@@ -8,28 +8,27 @@ mod test_note {
     #[test]
     fn test_pitch_class_from_str() {
         let table = vec![
-            ("Cb", B),
-            ("C#", Cs),
-            ("C#", Cs),
-            ("C♯", Cs),
-            ("D", D),
-            ("Db", Cs),
-            ("Ds", Ds),
-            ("E", E),
-            ("Es", F),
-            ("Eb", Ds),
-            ("F", F),
-            ("f", F),
-            ("Fb", E),
-            ("G", G),
-            ("Gb", Fs),
-            ("Gs", Gs),
-            ("A", A),
-            ("As", As),
-            ("Ab", Gs),
-            ("B", B),
-            ("B♯", C),
-            ("Bb", As),
+            ("Cb", pclass(C,-1)),
+            ("C#", pclass(C,1)),
+            ("C♯", pclass(C,1)),
+            ("D",  pclass(D,0)),
+            ("Db", pclass(D,-1)),
+            ("Ds", pclass(D,1)),
+            ("E",  pclass(E,0)),
+            ("Es", pclass(E,1)),
+            ("Eb", pclass(E,-1)),
+            ("F",  pclass(F,0)),
+            ("f",  pclass(F,0)),
+            ("Fb", pclass(F,-1)),
+            ("G",  pclass(G,0)),
+            ("Gb", pclass(G,-1)),
+            ("Gs", pclass(G,1)),
+            ("A",  pclass(A,0)),
+            ("As", pclass(A,1)),
+            ("Ab", pclass(A,-1)),
+            ("B",  pclass(B,0)),
+            ("B♯", pclass(B,1)),
+            ("Bb", pclass(B,-1)),
         ];
 
         for (string, pitch_class) in table {
@@ -42,18 +41,18 @@ mod test_note {
     #[test]
     fn test_pitch_class_into_u8() {
         let table = vec![
-            (C, 0),
-            (Cs, 1),
-            (D, 2),
-            (Ds, 3),
-            (E, 4),
-            (F, 5),
-            (Fs, 6),
-            (G, 7),
-            (Gs, 8),
-            (A, 9),
-            (As, 10),
-            (B, 11),
+            (pclass(C,0), 0),
+            (pclass(C,1), 1),
+            (pclass(D,0), 2),
+            (pclass(D,1), 3),
+            (pclass(E,0), 4),
+            (pclass(F,0), 5),
+            (pclass(F,1), 6),
+            (pclass(G,0), 7),
+            (pclass(G,1), 8),
+            (pclass(A,0), 9),
+            (pclass(A,1), 10),
+            (pclass(B,0), 11),
         ];
 
         for (pitch_class, number) in table {

--- a/tests/scale/test_regex.rs
+++ b/tests/scale/test_regex.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::PitchClass::*;
+use theory::note::{PitchSymbol::*, pclass};
 use theory::scale::{Mode, Scale, ScaleType};
 
 #[cfg(test)]
@@ -9,26 +9,26 @@ mod chord_regex_tests {
     #[test]
     fn test_all_scales() {
         let table = vec![
-            ("C Major", C, ScaleType::Diatonic, Mode::Ionian),
-            ("CM", C, ScaleType::Diatonic, Mode::Ionian),
-            ("C Maj", C, ScaleType::Diatonic, Mode::Ionian),
-            ("C MAJOR", C, ScaleType::Diatonic, Mode::Ionian),
-            ("As locrian", As, ScaleType::Diatonic, Mode::Locrian),
-            ("Bs phrygian", C, ScaleType::Diatonic, Mode::Phrygian),
-            ("E lydian", E, ScaleType::Diatonic, Mode::Lydian),
-            ("F dorian", F, ScaleType::Diatonic, Mode::Dorian),
-            ("Gb mixolydian", Fs, ScaleType::Diatonic, Mode::Mixolydian),
-            ("B MAJOR", B, ScaleType::Diatonic, Mode::Ionian),
-            ("Bb MAJOR", As, ScaleType::Diatonic, Mode::Ionian),
+            ("C Major", pclass(C,0), ScaleType::Diatonic, Mode::Ionian),
+            ("CM", pclass(C,0), ScaleType::Diatonic, Mode::Ionian),
+            ("C Maj", pclass(C,0), ScaleType::Diatonic, Mode::Ionian),
+            ("C MAJOR", pclass(C,0), ScaleType::Diatonic, Mode::Ionian),
+            ("As locrian", pclass(A,1), ScaleType::Diatonic, Mode::Locrian),
+            ("Bs phrygian", pclass(B,1), ScaleType::Diatonic, Mode::Phrygian),
+            ("E lydian", pclass(E,0), ScaleType::Diatonic, Mode::Lydian),
+            ("F dorian", pclass(F,0), ScaleType::Diatonic, Mode::Dorian),
+            ("Gb mixolydian", pclass(G,-1), ScaleType::Diatonic, Mode::Mixolydian),
+            ("B MAJOR", pclass(B,0), ScaleType::Diatonic, Mode::Ionian),
+            ("Bb MAJOR", pclass(B,-1), ScaleType::Diatonic, Mode::Ionian),
             (
                 "Bb Harmonic Minor",
-                As,
+                pclass(B,-1),
                 ScaleType::HarmonicMinor,
                 Mode::HarmonicMinor,
             ),
             (
                 "Ds Melodic Minor",
-                Ds,
+                pclass(D,1),
                 ScaleType::MelodicMinor,
                 Mode::MelodicMinor,
             ),

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::{PitchClass::*, *};
+use theory::note::{PitchSymbol::*, *};
 use theory::scale::{Mode::*, ScaleType::*, *};
 
 fn assert_notes(pitches: &[PitchClass], notes: Vec<Note>) {
@@ -16,44 +16,44 @@ mod scale_tests {
     fn test_all_scales_in_c() {
         let scale_tuples = [
             (
-                Scale::new(Diatonic, C, 4, Some(Ionian)).unwrap(),
-                vec![C, D, E, F, G, A, B, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Ionian)).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(E,0), pclass(F,0), pclass(G,0), pclass(A,0), pclass(B,0), pclass(C,0)],
             ),
             (
-                Scale::new(Diatonic, C, 4, Some(Locrian)).unwrap(),
-                vec![C, Cs, Ds, F, Fs, Gs, As, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Locrian)).unwrap(),
+                vec![pclass(C,0), pclass(C,1), pclass(D,1), pclass(F,0), pclass(F,1), pclass(G,1), pclass(A,1), pclass(C,0)],
             ),
             (
-                Scale::new(Diatonic, B, 4, Some(Locrian)).unwrap(),
-                vec![B, C, D, E, F, G, A, B],
+                Scale::new(Diatonic, pclass(B,0), 4, Some(Locrian)).unwrap(),
+                vec![pclass(B,0), pclass(C,0), pclass(D,0), pclass(E,0), pclass(F,0), pclass(G,0), pclass(A,0), pclass(B,0)],
             ),
             (
-                Scale::new(Diatonic, C, 4, Some(Dorian)).unwrap(),
-                vec![C, D, Ds, F, G, A, As, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Dorian)).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(D,1), pclass(F,0), pclass(G,0), pclass(A,0), pclass(A,1), pclass(C,0)],
             ),
             (
-                Scale::new(Diatonic, A, 4, Some(Aeolian)).unwrap(),
-                vec![A, B, C, D, E, F, G, A],
+                Scale::new(Diatonic, pclass(A,0), 4, Some(Aeolian)).unwrap(),
+                vec![pclass(A,0), pclass(B,0), pclass(C,0), pclass(D,0), pclass(E,0), pclass(F,0), pclass(G,0), pclass(A,0)],
             ),
             (
-                Scale::new(Diatonic, C, 4, Some(Lydian)).unwrap(),
-                vec![C, D, E, Fs, G, A, B, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Lydian)).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(E,0), pclass(F,1), pclass(G,0), pclass(A,0), pclass(B,0), pclass(C,0)],
             ),
             (
-                Scale::new(Diatonic, C, 4, Some(Mixolydian)).unwrap(),
-                vec![C, D, E, F, G, A, As, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Mixolydian)).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(E,0), pclass(F,0), pclass(G,0), pclass(A,0), pclass(A,1), pclass(C,0)],
             ),
             (
-                Scale::new(Diatonic, C, 4, Some(Phrygian)).unwrap(),
-                vec![C, Cs, Ds, F, G, Gs, As, C],
+                Scale::new(Diatonic, pclass(C,0), 4, Some(Phrygian)).unwrap(),
+                vec![pclass(C,0), pclass(C,1), pclass(D,1), pclass(F,0), pclass(G,0), pclass(G,1), pclass(A,1), pclass(C,0)],
             ),
             (
-                Scale::new(ScaleType::HarmonicMinor, C, 4, None).unwrap(),
-                vec![C, D, Ds, F, G, Gs, B, C],
+                Scale::new(ScaleType::HarmonicMinor, pclass(C,0), 4, None).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(D,1), pclass(F,0), pclass(G,0), pclass(G,1), pclass(B,0), pclass(C,0)],
             ),
             (
-                Scale::new(ScaleType::MelodicMinor, C, 4, None).unwrap(),
-                vec![C, D, Ds, F, G, A, B, C],
+                Scale::new(ScaleType::MelodicMinor, pclass(C,0), 4, None).unwrap(),
+                vec![pclass(C,0), pclass(D,0), pclass(D,1), pclass(F,0), pclass(G,0), pclass(A,0), pclass(B,0), pclass(C,0)],
             ),
         ];
 
@@ -73,7 +73,7 @@ mod scale_tests {
     fn test_octave_increment() {
         let scale = Scale::new(
             ScaleType::Diatonic,
-            PitchClass::G,
+            pclass(PitchSymbol::G,0),
             5,
             Some(Mode::Mixolydian)
         ).unwrap();


### PR DESCRIPTION
This opens the door for proper enharmonic spelling and arbitrary accidentals.