### PR TITLE
Allow inversion of intervals, descent by intervals, and descending scales

### DIFF
--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -1,7 +1,7 @@
 use clap::{App, Arg, ArgMatches};
 use rust_music_theory::chord::Chord;
 use rust_music_theory::note::Notes;
-use rust_music_theory::scale::Scale;
+use rust_music_theory::scale::{Direction, Scale};
 
 const AVAILABLE_SCALES: [&str; 9] = [
     "Major|Ionian",
@@ -41,6 +41,7 @@ const AVAILABLE_CHORDS: [&str; 22] = [
 ];
 
 fn scale_command(scale_matches: &ArgMatches) {
+    use Direction::*;
     match scale_matches.subcommand() {
         ("list", _) => {
             println!("Available Scales:");
@@ -55,7 +56,10 @@ fn scale_command(scale_matches: &ArgMatches) {
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            let scale = Scale::from_regex(&scale_args).unwrap();
+            let descending = scale_matches.is_present("descending");
+            let direction = if descending { Descending } else { Ascending };
+
+            let scale = Scale::from_regex_in_direction(&scale_args, direction).unwrap();
             scale.print_notes();
         }
     }
@@ -95,6 +99,12 @@ fn main() {
                     Arg::with_name("args")
                         .help("scale args, examples:\nC melodic minor\nD# dorian")
                         .multiple(true),
+                )
+                .arg(
+                    Arg::with_name("descending")
+                        .help("list scale in descending order")
+                        .short("d")
+                        .long("descending"),
                 ),
         )
         .subcommand(

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -159,6 +159,15 @@ impl Interval {
         })
     }
 
+    pub fn invert(interval: &Self) -> Interval {
+        if interval.semitone_count == 12 {
+            Self::from_semitone(12).unwrap()
+        } else {
+            let adjusted = (12 + (12i16 - interval.semitone_count as i16)) % 12;
+            Self::from_semitone(adjusted as u8).unwrap()
+        }
+    }
+
     /// Move the given note up by this interval.
     pub fn second_note_from(self, first_note: Note) -> Note {
         let pitch_class = PitchClass::from_interval(first_note.pitch_class, self);
@@ -192,6 +201,28 @@ impl Interval {
             let last_note = notes.last().unwrap();
             let interval_first_note = Note::new(last_note.pitch_class, last_note.octave);
             let interval_second_note = interval.second_note_from(interval_first_note);
+            notes.push(interval_second_note);
+        }
+
+        notes
+    }
+
+    /// Produce the list of notes that have had each interval applied in order.
+    pub fn to_notes_reverse(
+        root: Note,
+        intervals: impl IntoIterator<Item = Interval>,
+    ) -> Vec<Note> {
+        let mut notes = vec![root];
+
+        let reversed = intervals
+            .into_iter()
+            .collect::<Vec<Interval>>()
+            .into_iter()
+            .rev();
+        for interval in reversed {
+            let last_note = notes.last().unwrap();
+            let interval_first_note = Note::new(last_note.pitch_class, last_note.octave);
+            let interval_second_note = interval.second_note_down_from(interval_first_note);
             notes.push(interval_second_note);
         }
 

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -161,12 +161,12 @@ impl Interval {
 
     /// Creates an interval by inverting the given interval
     /// e.g. Perfect fifth (C to G) becomes a perfect fourth (G to C)
-    pub fn invert(interval: &Self) -> Interval {
+    pub fn invert(interval: &Self) -> Result<Self, IntervalError> {
         if interval.semitone_count == 12 {
-            Self::from_semitone(12).unwrap()
+            Self::from_semitone(12)
         } else {
             let adjusted = (12 + (12i16 - interval.semitone_count as i16)) % 12;
-            Self::from_semitone(adjusted as u8).unwrap()
+            Self::from_semitone(adjusted as u8)
         }
     }
 

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -171,6 +171,19 @@ impl Interval {
         }
     }
 
+    /// Move the given note down by this interval.
+    pub fn second_note_down_from(self, first_note: Note) -> Note {
+        let pitch_class = PitchClass::from_interval_down(first_note.pitch_class, self);
+        let octave = first_note.octave;
+        let raw_diff = first_note.pitch_class as i16 - self.semitone_count as i16;
+        let excess_octave = (raw_diff / -12) + if raw_diff < 0 { 1 } else { 0 };
+
+        Note {
+            octave: octave - excess_octave as u8,
+            pitch_class,
+        }
+    }
+
     /// Produce the list of notes that have had each interval applied in order.
     pub fn to_notes(root: Note, intervals: impl IntoIterator<Item = Interval>) -> Vec<Note> {
         let mut notes = vec![root];

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -159,6 +159,8 @@ impl Interval {
         })
     }
 
+    /// Creates an interval by inverting the given interval
+    /// e.g. Perfect fifth (C to G) becomes a perfect fourth (G to C)
     pub fn invert(interval: &Self) -> Interval {
         if interval.semitone_count == 12 {
             Self::from_semitone(12).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! ```no_run
 //! extern crate rust_music_theory as rustmt;
 //! use rustmt::note::{Note, Notes, PitchClass};
-//! use rustmt::scale::{Scale, ScaleType, Mode};
+//! use rustmt::scale::{Direction, Scale, ScaleType, Mode};
 //! use rustmt::chord::{Chord, Number as ChordNumber, Quality as ChordQuality};
 //!
 //! // to create a Note, specify a pitch class and an octave;
@@ -28,6 +28,7 @@
 //!     PitchClass::C,          // tonic
 //!     4,                      // octave
 //!     Some(Mode::Ionian),     // scale mode
+//!     Direction::Ascending,   // direction
 //! ).unwrap();
 //!
 //! // returns a Vector of the Notes of the scale

--- a/src/note/pitch_class.rs
+++ b/src/note/pitch_class.rs
@@ -101,6 +101,14 @@ impl PitchClass {
         Self::from_u8(new_pitch)
     }
 
+    /// Create a note by moving down the given note by an interval.
+    pub fn from_interval_down(pitch: Self, interval: Interval) -> Self {
+        let current_pitch = pitch.into_u8();
+        let new_pitch = (12 + (current_pitch as i16 - interval.semitone_count as i16)) % 12;
+
+        Self::from_u8(new_pitch as u8)
+    }
+
     /// Parse the note using a regex, with the same algorithm as described in `from_str`.
     pub fn from_regex(string: &str) -> Result<(Self, Match), NoteError> {
         let pitch_match = REGEX_PITCH.find(&string).ok_or(NoteError::InvalidPitch)?;

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -6,5 +6,5 @@ mod scale;
 mod scale_type;
 
 pub use mode::Mode;
-pub use scale::Scale;
+pub use scale::{Direction, Scale};
 pub use scale_type::ScaleType;

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -29,12 +29,23 @@ pub struct Scale {
 }
 
 impl Scale {
-    /// Create a new scale.
+    /// Create a new ascending scale.
     pub fn new(
         scale_type: ScaleType,
         tonic: PitchClass,
         octave: u8,
         mode: Option<Mode>,
+    ) -> Result<Self, ScaleError> {
+        Self::new_in_direction(scale_type, tonic, octave, mode, Direction::Ascending)
+    }
+
+    /// Create a new scale with a given direction.
+    pub fn new_in_direction(
+        scale_type: ScaleType,
+        tonic: PitchClass,
+        octave: u8,
+        mode: Option<Mode>,
+        direction: Direction,
     ) -> Result<Self, ScaleError> {
         let intervals = match scale_type {
             ScaleType::Diatonic => Interval::from_semitones(&[2, 2, 1, 2, 2, 2, 1]),
@@ -48,19 +59,23 @@ impl Scale {
             scale_type,
             mode,
             intervals,
-            ..Default::default()
+            direction,
         })
     }
 
     /// Parse a scale from a regex.
-    pub fn from_regex(string: &str) -> Result<Self, ScaleError> {
+    pub fn from_regex_in_direction(string: &str, direction: Direction) -> Result<Self, ScaleError> {
         let (tonic, tonic_match) = PitchClass::from_regex(&string.trim())?;
         let mode_string = &string[tonic_match.end()..].trim();
         let (mode, _) = Mode::from_regex(mode_string)?;
         let scale_type = ScaleType::from_mode(mode);
         let octave = 4;
-        let scale = Scale::new(scale_type, tonic, octave, Some(mode))?;
+        let scale = Scale::new_in_direction(scale_type, tonic, octave, Some(mode), direction)?;
         Ok(scale)
+    }
+
+    pub fn from_regex(string: &str) -> Result<Self, ScaleError> {
+        Self::from_regex_in_direction(string, Direction::Ascending)
     }
 }
 

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -66,6 +66,7 @@ impl Scale {
 
 impl Notes for Scale {
     fn notes(&self) -> Vec<Note> {
+        use Direction::*;
         use Mode::*;
         let root_note = Note {
             octave: self.octave,
@@ -91,7 +92,10 @@ impl Notes for Scale {
             }
         };
 
-        Interval::to_notes(root_note, intervals_clone)
+        match &self.direction {
+            Ascending => Interval::to_notes(root_note, intervals_clone),
+            Descending => Interval::to_notes_reverse(root_note, intervals_clone),
+        }
     }
 }
 

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -29,18 +29,8 @@ pub struct Scale {
 }
 
 impl Scale {
-    /// Create a new ascending scale.
-    pub fn new(
-        scale_type: ScaleType,
-        tonic: PitchClass,
-        octave: u8,
-        mode: Option<Mode>,
-    ) -> Result<Self, ScaleError> {
-        Self::new_in_direction(scale_type, tonic, octave, mode, Direction::Ascending)
-    }
-
     /// Create a new scale with a given direction.
-    pub fn new_in_direction(
+    pub fn new(
         scale_type: ScaleType,
         tonic: PitchClass,
         octave: u8,
@@ -70,7 +60,7 @@ impl Scale {
         let (mode, _) = Mode::from_regex(mode_string)?;
         let scale_type = ScaleType::from_mode(mode);
         let octave = 4;
-        let scale = Scale::new_in_direction(scale_type, tonic, octave, Some(mode), direction)?;
+        let scale = Scale::new(scale_type, tonic, octave, Some(mode), direction)?;
         Ok(scale)
     }
 

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -1,0 +1,44 @@
+extern crate rust_music_theory as theory;
+use theory::interval::Interval;
+use theory::note::{Note, PitchClass::*};
+
+#[cfg(test)]
+mod test_interval {
+    use super::*;
+
+    #[test]
+    fn test_second_note_from() {
+        let notes = vec![(C, 3), (D, 3), (E, 3), (Fs, 3), (Gs, 3), (As, 3), (C, 4)]
+            .into_iter()
+            .map(|note| Note {
+                pitch_class: note.0,
+                octave: note.1,
+            })
+            .collect::<Vec<Note>>();
+
+        let major_second = Interval::from_semitone(2).unwrap();
+        for i in 0..(notes.len() - 1) {
+            let next_note = major_second.second_note_from(notes[i].clone());
+            assert_eq!(next_note.pitch_class, notes[i + 1].pitch_class);
+            assert_eq!(next_note.octave, notes[i + 1].octave);
+        }
+    }
+
+    #[test]
+    fn test_second_note_down_from() {
+        let notes = vec![(C, 4), (As, 3), (Gs, 3), (Fs, 3), (E, 3), (D, 3), (C, 3)]
+            .into_iter()
+            .map(|note| Note {
+                pitch_class: note.0,
+                octave: note.1,
+            })
+            .collect::<Vec<Note>>();
+
+        let major_second = Interval::from_semitone(2).unwrap();
+        for i in 0..(notes.len() - 1) {
+            let next_note = major_second.second_note_down_from(notes[i].clone());
+            assert_eq!(next_note.pitch_class, notes[i + 1].pitch_class);
+            assert_eq!(next_note.octave, notes[i + 1].octave);
+        }
+    }
+}

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -71,10 +71,9 @@ mod test_interval {
     #[test]
     fn test_invert_unison() {
         let unison = Interval::from_semitone(0).unwrap();
-        assert_eq!(
-            unison.semitone_count,
-            Interval::invert(&unison).semitone_count
-        )
+        let inverted = Interval::invert(&unison);
+        assert!(inverted.is_ok());
+        assert_eq!(inverted.unwrap().semitone_count, unison.semitone_count);
     }
 
     #[test]
@@ -83,10 +82,9 @@ mod test_interval {
 
         for i in 0..list.len() {
             let interval = Interval::from_semitone(list[i]).unwrap();
-            assert_eq!(
-                Interval::invert(&interval).semitone_count,
-                list[list.len() - i - 1]
-            );
+            let inverted = Interval::invert(&interval);
+            assert!(inverted.is_ok());
+            assert_eq!(inverted.unwrap().semitone_count, list[list.len() - i - 1]);
         }
     }
 }

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -67,4 +67,26 @@ mod test_interval {
             assert_eq!(next_note.octave, note.octave - 1);
         }
     }
+
+    #[test]
+    fn test_invert_unison() {
+        let unison = Interval::from_semitone(0).unwrap();
+        assert_eq!(
+            unison.semitone_count,
+            Interval::invert(&unison).semitone_count
+        )
+    }
+
+    #[test]
+    fn test_invert() {
+        let list = vec![12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+        for i in 0..list.len() {
+            let interval = Interval::from_semitone(list[i]).unwrap();
+            assert_eq!(
+                Interval::invert(&interval).semitone_count,
+                list[list.len() - i - 1]
+            );
+        }
+    }
 }

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -41,4 +41,30 @@ mod test_interval {
             assert_eq!(next_note.octave, notes[i + 1].octave);
         }
     }
+
+    #[test]
+    fn test_octave_jump() {
+        let octave_interval = Interval::from_semitone(12).unwrap();
+        for octave in 0..=8 {
+            let note = Note {
+                pitch_class: C,
+                octave,
+            };
+            let next_note = octave_interval.second_note_from(note.clone());
+            assert_eq!(next_note.octave, note.octave + 1);
+        }
+    }
+
+    #[test]
+    fn test_octave_jump_down() {
+        let octave_interval = Interval::from_semitone(12).unwrap();
+        for octave in 8..=0 {
+            let note = Note {
+                pitch_class: C,
+                octave,
+            };
+            let next_note = octave_interval.second_note_down_from(note.clone());
+            assert_eq!(next_note.octave, note.octave - 1);
+        }
+    }
 }

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -15,60 +15,37 @@ mod scale_tests {
     #[test]
     fn test_all_scales_in_c() {
         let scale_tuples = [
+            ((Diatonic, Some(Ionian)), vec![C, D, E, F, G, A, B, C]),
+            ((Diatonic, Some(Dorian)), vec![C, D, Ds, F, G, A, As, C]),
+            ((Diatonic, Some(Phrygian)), vec![C, Cs, Ds, F, G, Gs, As, C]),
+            ((Diatonic, Some(Lydian)), vec![C, D, E, Fs, G, A, B, C]),
+            ((Diatonic, Some(Mixolydian)), vec![C, D, E, F, G, A, As, C]),
+            ((Diatonic, Some(Aeolian)), vec![C, D, Ds, F, G, Gs, As, C]),
+            ((Diatonic, Some(Locrian)), vec![C, Cs, Ds, F, Fs, Gs, As, C]),
             (
-                Scale::new(Diatonic, C, 4, Some(Ionian)).unwrap(),
-                vec![C, D, E, F, G, A, B, C],
-            ),
-            (
-                Scale::new(Diatonic, C, 4, Some(Locrian)).unwrap(),
-                vec![C, Cs, Ds, F, Fs, Gs, As, C],
-            ),
-            (
-                Scale::new(Diatonic, B, 4, Some(Locrian)).unwrap(),
-                vec![B, C, D, E, F, G, A, B],
-            ),
-            (
-                Scale::new(Diatonic, C, 4, Some(Dorian)).unwrap(),
-                vec![C, D, Ds, F, G, A, As, C],
-            ),
-            (
-                Scale::new(Diatonic, A, 4, Some(Aeolian)).unwrap(),
-                vec![A, B, C, D, E, F, G, A],
-            ),
-            (
-                Scale::new(Diatonic, C, 4, Some(Lydian)).unwrap(),
-                vec![C, D, E, Fs, G, A, B, C],
-            ),
-            (
-                Scale::new(Diatonic, C, 4, Some(Mixolydian)).unwrap(),
-                vec![C, D, E, F, G, A, As, C],
-            ),
-            (
-                Scale::new(Diatonic, C, 4, Some(Phrygian)).unwrap(),
-                vec![C, Cs, Ds, F, G, Gs, As, C],
-            ),
-            (
-                Scale::new(ScaleType::HarmonicMinor, C, 4, None).unwrap(),
+                (ScaleType::HarmonicMinor, None),
                 vec![C, D, Ds, F, G, Gs, B, C],
             ),
             (
-                Scale::new(ScaleType::MelodicMinor, C, 4, None).unwrap(),
+                (ScaleType::MelodicMinor, None),
                 vec![C, D, Ds, F, G, A, B, C],
             ),
         ];
 
-        for scale_tuple in scale_tuples.iter() {
-            let (scale, pitches) = scale_tuple;
-            assert_notes(pitches, scale.notes());
+        for (scale_tuple, pitches) in scale_tuples.iter() {
+            let (scale_type, mode) = scale_tuple;
+            let scale_ascending =
+                Scale::new_in_direction(*scale_type, C, 4, *mode, Direction::Ascending).unwrap();
+            assert_notes(pitches, scale_ascending.notes());
 
-            let mut scale_descending = scale.clone();
-            scale_descending.direction = Direction::Descending;
+            let scale_descending =
+                Scale::new_in_direction(*scale_type, C, 4, *mode, Direction::Descending).unwrap();
             let mut pitches_descending = pitches.clone();
             pitches_descending.reverse();
             assert_notes(&pitches_descending, scale_descending.notes());
 
-            if scale.scale_type == Diatonic {
-                if let Some(mode) = scale.mode {
+            if scale_ascending.scale_type == Diatonic {
+                if let Some(mode) = scale_ascending.mode {
                     assert!(mode.is_diatonic());
                 }
             }

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -61,6 +61,12 @@ mod scale_tests {
             let (scale, pitches) = scale_tuple;
             assert_notes(pitches, scale.notes());
 
+            let mut scale_descending = scale.clone();
+            scale_descending.direction = Direction::Descending;
+            let mut pitches_descending = pitches.clone();
+            pitches_descending.reverse();
+            assert_notes(&pitches_descending, scale_descending.notes());
+
             if scale.scale_type == Diatonic {
                 if let Some(mode) = scale.mode {
                     assert!(mode.is_diatonic());
@@ -75,8 +81,9 @@ mod scale_tests {
             ScaleType::Diatonic,
             PitchClass::G,
             5,
-            Some(Mode::Mixolydian)
-        ).unwrap();
+            Some(Mode::Mixolydian),
+        )
+        .unwrap();
 
         for (i, note) in scale.notes().iter().enumerate() {
             assert_eq!(note.octave, if i <= 2 { 5 } else { 6 });

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -35,11 +35,11 @@ mod scale_tests {
         for (scale_tuple, pitches) in scale_tuples.iter() {
             let (scale_type, mode) = scale_tuple;
             let scale_ascending =
-                Scale::new_in_direction(*scale_type, C, 4, *mode, Direction::Ascending).unwrap();
+                Scale::new(*scale_type, C, 4, *mode, Direction::Ascending).unwrap();
             assert_notes(pitches, scale_ascending.notes());
 
             let scale_descending =
-                Scale::new_in_direction(*scale_type, C, 4, *mode, Direction::Descending).unwrap();
+                Scale::new(*scale_type, C, 4, *mode, Direction::Descending).unwrap();
             let mut pitches_descending = pitches.clone();
             pitches_descending.reverse();
             assert_notes(&pitches_descending, scale_descending.notes());
@@ -59,6 +59,7 @@ mod scale_tests {
             PitchClass::G,
             5,
             Some(Mode::Mixolydian),
+            Direction::Ascending,
         )
         .unwrap();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,3 +13,7 @@ mod scale {
 mod note {
     mod test_pitch_class;
 }
+
+mod interval {
+    mod test_interval;
+}


### PR DESCRIPTION
# Changes:

## Executable
- Added new `-d, --descending` option to `scale command`
    - Returns the scale in descending order
    - Uses the `direction` property of `Scale`, so this approach allows descending Melodic Minor to eventually be different from ascending

## Interval
- Added static method `Interval::invert(&Interval)` that returns the inverse of the given interval _as a `Result`_
    - This uses the musical set theory definition of inverse
    - Identities: P0&#8594;P0, P8&#8594;P8, TT&#8594;TT
    - Other examples: P5&#8594;P4, M2&#8594;m7
- Added member function `second_note_down_from(self, Note)` that is the opposite of `second_note_from`
    - Correctly accounts for octaves
- Added static method `to_notes_reverse(Note, impl IntoIterator<Item = Interval>) that is the opposite of `to_notes`
    - Takes the list of intervals **backwards** and builds downwards from the given root
- A new folder of tests just for intervals, including extensive testing of inverse intervals

## Pitch Class
- Added static method `from_interval_down(Self, Interval)` that gets the pitch class created by descending the given pitch class by the given interval
    - Uses a modified modulus formula: `b+ (c - d)) % b` to prevent errors and allow eventual addition of compound intervals (like M13)

## Scale
- Modified the `new` constructor to accept a `Direction`
- Made a similar pair of changes by adding `from_regex_in_direction`
- Added check for direction in `impl Notes::notes for Scale`
- Reworked test of all scales in C
    - They all actually start on C now
    - Tuples of basic descriptors of scales, then the constructors are used to make ascending and descending versions