### PR TITLE
Chord inversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,6 @@ Notes:
     - [ ] Add support for arbitrary accidentals
     - [ ] Add support for the alternative names of the modes to regex parser
 - [ ] Properly display enharmonic spelling
-- [ ] Add inversion support for chords
+- [x] Add inversion support for chords
 - [ ] Add support for [cadence][1]s
 - [ ] Add a mechanism to find the chord from the given notes

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -103,7 +103,7 @@ fn main() {
                 .subcommand(App::new("list").about("Prints out the available chords"))
                 .arg(
                     Arg::with_name("args")
-                        .help("chord args, examples:\nC minor\nAb augmented major seventh")
+                        .help("chord args, examples:\nC minor\nAb augmented major seventh\nF# dominant seventh / C#")
                         .multiple(true),
                 ),
         )

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -113,7 +113,7 @@ fn main() {
                 .subcommand(App::new("list").about("Prints out the available chords"))
                 .arg(
                     Arg::with_name("args")
-                        .help("chord args, examples:\nC minor\nAb augmented major seventh\nF# dominant seventh / C#")
+                        .help("chord args, examples:\nC minor\nAb augmented major seventh\nF# dominant seventh / C#\nC/1")
                         .multiple(true),
                 ),
         )

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -83,6 +83,28 @@ fn chord_command(chord_matches: &ArgMatches) {
 }
 
 fn main() {
+    {
+        use rust_music_theory::{
+            chord::{Number::*, Quality::*, *},
+            note::PitchClass::*,
+        };
+        println!("{:?}", Chord::with_inversion(C, Major, Triad, 0).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Triad, 1).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Triad, 2).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Triad, 3).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Triad, 4).notes());
+        println!();
+        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 0).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 1).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 2).notes());
+        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 3).notes());
+        println!();
+        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 0).notes());
+        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 1).notes());
+        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 2).notes());
+        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 3).notes());
+    }
+
     let matches = App::new("RustMusicTheory")
         .version("0.1")
         .author("Ozan Kaşıkçı")

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -83,28 +83,6 @@ fn chord_command(chord_matches: &ArgMatches) {
 }
 
 fn main() {
-    {
-        use rust_music_theory::{
-            chord::{Number::*, Quality::*, *},
-            note::PitchClass::*,
-        };
-        println!("{:?}", Chord::with_inversion(C, Major, Triad, 0).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Triad, 1).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Triad, 2).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Triad, 3).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Triad, 4).notes());
-        println!();
-        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 0).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 1).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 2).notes());
-        println!("{:?}", Chord::with_inversion(C, Major, Seventh, 3).notes());
-        println!();
-        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 0).notes());
-        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 1).notes());
-        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 2).notes());
-        println!("{:?}", Chord::with_inversion(G, Major, Seventh, 3).notes());
-    }
-
     let matches = App::new("RustMusicTheory")
         .version("0.1")
         .author("Ozan Kaşıkçı")

--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -34,7 +34,7 @@ impl Chord {
         number: Number,
         inversion: u8,
     ) -> Self {
-        let intervals = Self::chord_intervals(&quality, &number);
+        let intervals = Self::chord_intervals(quality, number);
         let inversion = inversion % (intervals.len() + 1) as u8;
         Chord {
             root,
@@ -46,7 +46,7 @@ impl Chord {
         }
     }
 
-    pub fn chord_intervals(quality: &Quality, number: &Number) -> Vec<Interval> {
+    pub fn chord_intervals(quality: Quality, number: Number) -> Vec<Interval> {
         use Number::*;
         use Quality::*;
         match (&quality, &number) {

--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -4,8 +4,6 @@ use crate::chord::{Number, Quality};
 use crate::interval::Interval;
 use crate::note::{Note, NoteError, Notes, PitchClass};
 
-use regex::{Match, Regex};
-
 /// A chord.
 #[derive(Debug, Clone)]
 pub struct Chord {
@@ -91,7 +89,7 @@ impl Chord {
         };
 
         let (quality, quality_match_option) = Quality::from_regex(
-            &string[pitch_match.end()..slash_option.unwrap_or(string.len())].trim(),
+            &string[pitch_match.end()..slash_option.unwrap_or_else(|| string.len())].trim(),
         )?;
 
         let number = if let Some(quality_match) = quality_match_option {

--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -87,6 +87,11 @@ impl Chord {
         } else {
             Err(NoteError::InvalidPitch)
         };
+        let inversion_num_option = if let Some(slash) = slash_option {
+            string[slash + 1..].trim().parse::<u8>().ok()
+        } else {
+            None
+        };
 
         let (quality, quality_match_option) = Quality::from_regex(
             &string[pitch_match.end()..slash_option.unwrap_or_else(|| string.len())].trim(),
@@ -99,7 +104,13 @@ impl Chord {
         } else {
             Triad
         };
-        let chord = Chord::new(pitch_class, quality, number);
+
+        let chord = Chord::with_inversion(
+            pitch_class,
+            quality,
+            number,
+            inversion_num_option.unwrap_or(0),
+        );
 
         if let Ok((bass_note, _)) = bass_note_result {
             let inversion = chord

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -77,9 +77,14 @@ mod chord_tests {
     #[test]
     fn test_inversion_regex() {
         let chord = Chord::from_regex("F/C");
+        let chord_num = Chord::from_regex("F/2");
         assert!(chord.is_ok());
+        assert!(chord_num.is_ok());
         let chord = chord.unwrap();
+        let chord_num = chord_num.unwrap();
         assert_notes(&vec![C, F, A], chord.notes());
+        assert_notes(&vec![C, F, A], chord_num.notes());
         assert_eq!(chord.inversion, 2);
+        assert_eq!(chord_num.inversion, 2);
     }
 }

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -15,36 +15,53 @@ mod chord_tests {
     #[test]
     fn test_all_chords_in_c() {
         let chord_tuples = [
-            (Chord::new(C, Major, Triad), vec![C, E, G]),
-            (Chord::new(C, Minor, Triad), vec![C, Ds, G]),
-            (Chord::new(C, Augmented, Triad), vec![C, E, Gs]),
-            (Chord::new(C, Diminished, Triad), vec![C, Ds, Fs]),
-            (Chord::new(C, Major, Seventh), vec![C, E, G, B]),
-            (Chord::new(C, Minor, Seventh), vec![C, Ds, G, As]),
-            (Chord::new(C, Augmented, Seventh), vec![C, E, Gs, As]),
-            (Chord::new(C, Augmented, MajorSeventh), vec![C, E, Gs, B]),
-            (Chord::new(C, Diminished, Seventh), vec![C, Ds, Fs, A]),
-            (Chord::new(C, HalfDiminished, Seventh), vec![C, Ds, Fs, As]),
-            (Chord::new(C, Minor, MajorSeventh), vec![C, Ds, G, B]),
-            (Chord::new(C, Dominant, Seventh), vec![C, E, G, As]),
+            ((C, Major, Triad), vec![C, E, G]),
+            ((C, Minor, Triad), vec![C, Ds, G]),
+            ((C, Augmented, Triad), vec![C, E, Gs]),
+            ((C, Diminished, Triad), vec![C, Ds, Fs]),
+            ((C, Major, Seventh), vec![C, E, G, B]),
+            ((C, Minor, Seventh), vec![C, Ds, G, As]),
+            ((C, Augmented, Seventh), vec![C, E, Gs, As]),
+            ((C, Augmented, MajorSeventh), vec![C, E, Gs, B]),
+            ((C, Diminished, Seventh), vec![C, Ds, Fs, A]),
+            ((C, HalfDiminished, Seventh), vec![C, Ds, Fs, As]),
+            ((C, Minor, MajorSeventh), vec![C, Ds, G, B]),
+            ((C, Dominant, Seventh), vec![C, E, G, As]),
         ];
 
-        for chord_tuple in chord_tuples.iter() {
-            let (chord, pitches) = chord_tuple;
-            assert_notes(pitches, chord.notes());
+        for (chord, pitches) in chord_tuples.iter() {
+            let classes = &mut pitches.clone();
+            for inversion in 0..pitches.len() {
+                assert_notes(
+                    &classes,
+                    Chord::with_inversion(chord.0, chord.1, chord.2, inversion as u8).notes(),
+                );
+                classes.rotate_left(1);
+            }
         }
     }
 
     #[test]
-    fn test_c_major_triad_inversions() {
-        let mut classes = vec![C, E, G];
-
-        for i in 0..classes.len() {
-            assert_notes(
-                &classes,
-                Chord::with_inversion(C, Major, Triad, i as u8).notes(),
+    fn test_inversion_octaves() {
+        let chord_desc = (G, Major, Ninth);
+        let octaves = [
+            [4u8, 4, 5, 5, 5],
+            [4, 5, 5, 5, 6],
+            [4, 4, 4, 5, 5],
+            [4, 4, 5, 5, 6],
+            [4, 5, 5, 6, 6],
+        ];
+        for inversion in 0..octaves[0].len() {
+            let notes =
+                Chord::with_inversion(chord_desc.0, chord_desc.1, chord_desc.2, inversion as u8)
+                    .notes();
+            assert_eq!(
+                notes
+                    .into_iter()
+                    .map(|note| note.octave)
+                    .collect::<Vec<u8>>(),
+                octaves[inversion]
             );
-            classes.rotate_left(1);
         }
     }
 }

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -34,4 +34,17 @@ mod chord_tests {
             assert_notes(pitches, chord.notes());
         }
     }
+
+    #[test]
+    fn test_c_major_triad_inversions() {
+        let mut classes = vec![C, E, G];
+
+        for i in 0..classes.len() {
+            assert_notes(
+                &classes,
+                Chord::with_inversion(C, Major, Triad, i as u8).notes(),
+            );
+            classes.rotate_left(1);
+        }
+    }
 }

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -64,4 +64,22 @@ mod chord_tests {
             );
         }
     }
+
+    #[test]
+    fn test_regex() {
+        let chord = Chord::from_regex("F major");
+        assert!(chord.is_ok());
+        let chord = chord.unwrap();
+        assert_notes(&vec![F, A, C], chord.notes());
+        assert_eq!(chord.inversion, 0);
+    }
+
+    #[test]
+    fn test_inversion_regex() {
+        let chord = Chord::from_regex("F/C");
+        assert!(chord.is_ok());
+        let chord = chord.unwrap();
+        assert_notes(&vec![C, F, A], chord.notes());
+        assert_eq!(chord.inversion, 2);
+    }
 }

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -75,8 +75,9 @@ mod scale_tests {
             ScaleType::Diatonic,
             PitchClass::G,
             5,
-            Some(Mode::Mixolydian)
-        ).unwrap();
+            Some(Mode::Mixolydian),
+        )
+        .unwrap();
 
         for (i, note) in scale.notes().iter().enumerate() {
             assert_eq!(note.octave, if i <= 2 { 5 } else { 6 });


### PR DESCRIPTION
## Executable
- Added support for inversions using slash syntax
    - `C major triad / E` is C major in first inversion
    - The implementation is similary error-proof to the other `from_regex` functions, so `C/E` and `C major /E` give the same result as the above
- Added inversion example to `chord help`

## chord.rs
- Added `inversion: u8` to `Chord`
- Added new constructor `with_inversion`, and made `new` construct a root-position chord by default
    - @ozankasikci correctly critiqued a similar design pattern I used for descending scales, but I think root position chords are desirable in the vast majority of cases, and that they are the "default" voicing of chords unless otherwise stated
- Modularized `chord_intervals` into its own function, giving the intervallic layout of a chord
- **Added inversion support to `from_regex`**
    - It checks if there is a `/` in the input, and if so, treats everything after the slash as a `PitchClass`
        - It uses `PitchClass::from_regex`, so it is error-safe
    - If a slash is given, followed by a valid pitch class, then:
        - The chord is first constructed in root position
        - The position of the given bass note is determined in the root position chord
        - A new chord is build with the determined inversion
    - Minimal overhead is created for invalid/root position inversions
- `impl Notes for Chord` generates the notes of the root position chord, rotates them based on the inversion number, and corrects the octaves such that they 1) are non-decreasing and 2) start at `self.octave`

## test_chord.rs
- `test_all_chords_in_c` now generates and tests all inversions of each chord type on C
- `test_inversion_octaves` tests against hard-coded octave lists for every inversion of a G major ninth chord

**Caveat: There is no standard (to my knowledge) for voicing inverted chords beyond the octave, i.e. placing `G` in `G major 9 / B`. For this reason (and to maximize simplicity and flexibility), my implementation enforces a non-decreasing order; `G major 9 = B4 D5 F#5 A5 G6`**