### PR TITLE
re: Change encoding of pitch classes

### DIFF
--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -150,7 +150,7 @@ impl Notes for Chord {
 
         // Ensure that octave increments at the right notes
         for i in 1..notes.len() {
-            if notes[i].pitch as u8 <= notes[i - 1].pitch as u8 {
+            if notes[i].pitch.into_u8() <= notes[i - 1].pitch.into_u8() {
                 notes[i].octave = notes[i - 1].octave + 1;
             } else if notes[i].octave < notes[i - 1].octave {
                 notes[i].octave = notes[i - 1].octave;

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -1,5 +1,5 @@
 use crate::interval::errors::IntervalError;
-use crate::note::{Note, PitchClass};
+use crate::note::{Note, Pitch};
 use strum_macros::Display;
 
 /// The quality of an interval; major, minor, etc.
@@ -172,9 +172,9 @@ impl Interval {
 
     /// Move the given note up by this interval.
     pub fn second_note_from(self, first_note: Note) -> Note {
-        let pitch_class = PitchClass::from_interval(first_note.pitch_class, self);
+        let pitch_class = Pitch::from_interval(first_note.pitch_class, self);
         let octave = first_note.octave;
-        let excess_octave = (first_note.pitch_class as u8 + self.semitone_count) / 12;
+        let excess_octave = (first_note.pitch_class.into_u8() + self.semitone_count) / 12;
 
         Note {
             octave: octave + excess_octave,
@@ -184,7 +184,7 @@ impl Interval {
 
     /// Move the given note down by this interval.
     pub fn second_note_down_from(self, first_note: Note) -> Note {
-        let pitch_class = PitchClass::from_interval_down(first_note.pitch_class, self);
+        let pitch_class = Pitch::from_interval_down(first_note.pitch_class, self);
         let octave = first_note.octave;
         let raw_diff = first_note.pitch_class as i16 - self.semitone_count as i16;
         let excess_octave = (raw_diff / -12) + if raw_diff < 0 { 1 } else { 0 };

--- a/src/interval/interval.rs
+++ b/src/interval/interval.rs
@@ -172,26 +172,26 @@ impl Interval {
 
     /// Move the given note up by this interval.
     pub fn second_note_from(self, first_note: Note) -> Note {
-        let pitch_class = Pitch::from_interval(first_note.pitch_class, self);
+        let pitch = Pitch::from_interval(first_note.pitch, self);
         let octave = first_note.octave;
-        let excess_octave = (first_note.pitch_class.into_u8() + self.semitone_count) / 12;
+        let excess_octave = (first_note.pitch.into_u8() + self.semitone_count) / 12;
 
         Note {
             octave: octave + excess_octave,
-            pitch_class,
+            pitch,
         }
     }
 
     /// Move the given note down by this interval.
     pub fn second_note_down_from(self, first_note: Note) -> Note {
-        let pitch_class = Pitch::from_interval_down(first_note.pitch_class, self);
+        let pitch = Pitch::from_interval_down(first_note.pitch, self);
         let octave = first_note.octave;
-        let raw_diff = first_note.pitch_class as i16 - self.semitone_count as i16;
+        let raw_diff = first_note.pitch.into_u8() as i16 - self.semitone_count as i16;
         let excess_octave = (raw_diff / -12) + if raw_diff < 0 { 1 } else { 0 };
 
         Note {
             octave: octave - excess_octave as u8,
-            pitch_class,
+            pitch,
         }
     }
 
@@ -201,7 +201,7 @@ impl Interval {
 
         for interval in intervals {
             let last_note = notes.last().unwrap();
-            let interval_first_note = Note::new(last_note.pitch_class, last_note.octave);
+            let interval_first_note = Note::new(last_note.pitch, last_note.octave);
             let interval_second_note = interval.second_note_from(interval_first_note);
             notes.push(interval_second_note);
         }
@@ -223,7 +223,7 @@ impl Interval {
             .rev();
         for interval in reversed {
             let last_note = notes.last().unwrap();
-            let interval_first_note = Note::new(last_note.pitch_class, last_note.octave);
+            let interval_first_note = Note::new(last_note.pitch, last_note.octave);
             let interval_second_note = interval.second_note_down_from(interval_first_note);
             notes.push(interval_second_note);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,18 +14,18 @@
 //!
 //! ```no_run
 //! extern crate rust_music_theory as rustmt;
-//! use rustmt::note::{Note, Notes, PitchClass};
+//! use rustmt::note::{Note, Notes, Pitch, PitchSymbol::*};
 //! use rustmt::scale::{Direction, Scale, ScaleType, Mode};
 //! use rustmt::chord::{Chord, Number as ChordNumber, Quality as ChordQuality};
 //!
 //! // to create a Note, specify a pitch class and an octave;
-//! let note = Note::new(PitchClass::As, 4);
-//! // Note { pitch_class: A, octave: 4 }
+//! let note = Note::new(As, 4);
+//! // Note { As, octave: 4 }
 //!
 //! // Scale Example;
 //! let scale = Scale::new(
 //!     ScaleType::Diatonic,    // scale type
-//!     PitchClass::C,          // tonic
+//!     C,                      // tonic
 //!     4,                      // octave
 //!     Some(Mode::Ionian),     // scale mode
 //!     Direction::Ascending,   // direction
@@ -35,7 +35,7 @@
 //! let scale_notes = scale.notes();
 //!
 //! // Chord Example;
-//! let chord = Chord::new(PitchClass::C, ChordQuality::Major, ChordNumber::Triad);
+//! let chord = Chord::new(C, ChordQuality::Major, ChordNumber::Triad);
 //!
 //! // returns a Vector of the Notes of the chord
 //! let chord_notes = chord.notes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,13 @@
 //! use rustmt::chord::{Chord, Number as ChordNumber, Quality as ChordQuality};
 //!
 //! // to create a Note, specify a pitch class and an octave;
-//! let note = Note::new(As, 4);
-//! // Note { As, octave: 4 }
+//! let note = Note::new(Pitch::from(As), 4);
+//! // Note { pitch(NoteLetter::A, 1), octave: 4 }
 //!
 //! // Scale Example;
 //! let scale = Scale::new(
 //!     ScaleType::Diatonic,    // scale type
-//!     C,                      // tonic
+//!     Pitch::from(C),                      // tonic
 //!     4,                      // octave
 //!     Some(Mode::Ionian),     // scale mode
 //!     Direction::Ascending,   // direction
@@ -35,7 +35,7 @@
 //! let scale_notes = scale.notes();
 //!
 //! // Chord Example;
-//! let chord = Chord::new(C, ChordQuality::Major, ChordNumber::Triad);
+//! let chord = Chord::new(Pitch::from(C), ChordQuality::Major, ChordNumber::Triad);
 //!
 //! // returns a Vector of the Notes of the chord
 //! let chord_notes = chord.notes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! // to create a Note, specify a pitch class and an octave;
 //! let note = Note::new(Pitch::from(As), 4);
-//! // Note { pitch(NoteLetter::A, 1), octave: 4 }
+//! // Note { Pitch::new(NoteLetter::A, 1), octave: 4 }
 //!
 //! // Scale Example;
 //! let scale = Scale::new(

--- a/src/note.rs
+++ b/src/note.rs
@@ -3,7 +3,9 @@
 mod errors;
 mod note;
 mod pitch_class;
+mod pitch_symbol;
 
 pub use errors::NoteError;
 pub use note::{Note, Notes};
-pub use pitch_class::PitchClass;
+pub use pitch_class::{Pitch, NoteLetter, pitch};
+pub use pitch_symbol::PitchSymbol;

--- a/src/note.rs
+++ b/src/note.rs
@@ -7,5 +7,5 @@ mod pitch_symbol;
 
 pub use errors::NoteError;
 pub use note::{Note, Notes};
-pub use pitch::{Pitch, NoteLetter, pitch};
+pub use pitch::{Pitch, NoteLetter};
 pub use pitch_symbol::PitchSymbol;

--- a/src/note.rs
+++ b/src/note.rs
@@ -2,10 +2,10 @@
 
 mod errors;
 mod note;
-mod pitch_class;
+mod pitch;
 mod pitch_symbol;
 
 pub use errors::NoteError;
 pub use note::{Note, Notes};
-pub use pitch_class::{Pitch, NoteLetter, pitch};
+pub use pitch::{Pitch, NoteLetter, pitch};
 pub use pitch_symbol::PitchSymbol;

--- a/src/note/note.rs
+++ b/src/note/note.rs
@@ -1,21 +1,21 @@
-use crate::note::PitchClass;
+use crate::note::Pitch;
 use std::fmt;
 use std::fmt::Formatter;
 
 /// A note.
 #[derive(Debug, Clone)]
 pub struct Note {
-    /// The pitch class of the note (A, B, C#, etc).
-    pub pitch_class: PitchClass,
+    /// The pitch of the note (A, B, C#, etc).
+    pub pitch: Pitch,
     /// The octave of the note in standard notation.
     pub octave: u8,
 }
 
 impl Note {
     /// Create a new note.
-    pub fn new(pitch_class: PitchClass, octave: u8) -> Self {
+    pub fn new(pitch: Pitch, octave: u8) -> Self {
         Note {
-            pitch_class,
+            pitch,
             octave,
         }
     }
@@ -23,7 +23,7 @@ impl Note {
 
 impl fmt::Display for Note {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.pitch_class)
+        write!(f, "{}", self.pitch)
     }
 }
 
@@ -47,7 +47,7 @@ pub trait Notes {
 
         println!("Notes:");
         for (i, note) in notes.iter().enumerate() {
-            println!("  {}: {}", i + 1, note.pitch_class)
+            println!("  {}: {}", i + 1, note.pitch)
         }
     }
 }

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -136,21 +136,18 @@ impl Pitch {
 impl fmt::Display for Pitch {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use NoteLetter::*;
-        match self.letter {
-            C => write!(fmt, "C"),
-            D => write!(fmt, "D"),
-            E => write!(fmt, "E"),
-            F => write!(fmt, "F"),
-            G => write!(fmt, "G"),
-            A => write!(fmt, "A"),
-            B => write!(fmt, "B"),
-        }?;
+        let letter = match self.symbol {
+            C => "C",
+            D => "D",
+            E => "E",
+            F => "F",
+            G => "G",
+            A => "A",
+            B => "B",
+        };
 
-        match self.accidental {
-            1 => write!(fmt, "#"),
-            -1 => write!(fmt, "b"),
-            _ => Ok(()),
-        }
+        let flat = if self.accidental < 0 { "b" } else { "#" };
+        write!(fmt, "{}", letter.to_owned() + &(0..self.accidental.abs()).map(|_| flat).collect::<String>())
     }
 }
 

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -8,7 +8,7 @@ use strum_macros::EnumIter;
 use std::collections::HashMap;
 
 lazy_static! {
-    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭♯#s]*").unwrap();
+    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭♯#s𝄪x]*").unwrap();
 }
 
 /// A note letter without an accidental.

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -88,14 +88,14 @@ impl Pitch {
         };
 
         if let Some(second_char) = characters.next() {
-            match second_char {
+            return match second_char {
                 '#' | 's' | 'S' | '♯' => {
-                    return Some (Pitch { letter: symbol, accidental: 1 })
+                    Some(Pitch { letter: symbol, accidental: 1 })
                 }
                 'b' | '♭' => {
-                    return Some (Pitch { letter: symbol, accidental: -1 })
+                    Some(Pitch { letter: symbol, accidental: -1 })
                 }
-                _ => return None,
+                _ => None,
             }
         }
 
@@ -136,7 +136,7 @@ impl Pitch {
 impl fmt::Display for Pitch {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use NoteLetter::*;
-        let letter = match self.symbol {
+        let letter = match self.letter {
             C => "C",
             D => "D",
             E => "E",
@@ -146,8 +146,8 @@ impl fmt::Display for Pitch {
             B => "B",
         };
 
-        let flat = if self.accidental < 0 { "b" } else { "#" };
-        write!(fmt, "{}", letter.to_owned() + &(0..self.accidental.abs()).map(|_| flat).collect::<String>())
+        let acc = if self.accidental < 0 { "b" } else { "#" };
+        write!(fmt, "{}", letter.to_owned() + &(0..self.accidental.abs()).map(|_| acc).collect::<String>())
     }
 }
 

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -126,10 +126,10 @@ impl Pitch {
     pub fn from_regex(string: &str) -> Result<(Self, Match), NoteError> {
         let pitch_match = REGEX_PITCH.find(&string).ok_or(NoteError::InvalidPitch)?;
 
-        let pitch_class = Self::from_str(&string[pitch_match.start()..pitch_match.end()])
+        let pitch = Self::from_str(&string[pitch_match.start()..pitch_match.end()])
             .ok_or(NoteError::InvalidPitch)?;
 
-        Ok((pitch_class, pitch_match))
+        Ok((pitch, pitch_match))
     }
 }
 

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -8,7 +8,7 @@ use strum_macros::EnumIter;
 use std::collections::HashMap;
 
 lazy_static! {
-    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭♯#s]?").unwrap();
+    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭♯#s]*").unwrap();
 }
 
 /// A note letter without an accidental.

--- a/src/note/pitch_symbol.rs
+++ b/src/note/pitch_symbol.rs
@@ -1,4 +1,4 @@
-use crate::note::{Pitch, pitch, NoteLetter};
+use crate::note::{Pitch, NoteLetter};
 
 /// All possible pitches with accidentals.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -14,32 +14,33 @@ pub enum PitchSymbol {
     Gs, Ab,
     A,
     As, Bb,
-    B,
+    B, Cb,
 }
 
 impl From<PitchSymbol> for Pitch {
     fn from(symbol: PitchSymbol) -> Self {
         use PitchSymbol::*;
         match symbol {
-            Bs => pitch(NoteLetter::B, 1),
-            C => pitch(NoteLetter::C, 0),
-            Cs => pitch(NoteLetter::C, 1),
-            Db => pitch(NoteLetter::D, -1),
-            D => pitch(NoteLetter::D, 0),
-            Ds => pitch(NoteLetter::D, 1),
-            Eb => pitch(NoteLetter::E, -1),
-            E => pitch(NoteLetter::E, 0),
-            Es => pitch(NoteLetter::E, -1),
-            F => pitch(NoteLetter::F, 0),
-            Fs => pitch(NoteLetter::F, 1),
-            Gb => pitch(NoteLetter::G, -1),
-            G => pitch(NoteLetter::G, 0),
-            Gs => pitch(NoteLetter::G, 1),
-            Ab => pitch(NoteLetter::A, -1),
-            A => pitch(NoteLetter::A, 0),
-            As => pitch(NoteLetter::A, 1),
-            Bb => pitch(NoteLetter::B, -1),
-            B => pitch(NoteLetter::B, 0),
+            Bs => Pitch::new(NoteLetter::B, 1),
+            C => Pitch::new(NoteLetter::C, 0),
+            Cs => Pitch::new(NoteLetter::C, 1),
+            Db => Pitch::new(NoteLetter::D, -1),
+            D => Pitch::new(NoteLetter::D, 0),
+            Ds => Pitch::new(NoteLetter::D, 1),
+            Eb => Pitch::new(NoteLetter::E, -1),
+            E => Pitch::new(NoteLetter::E, 0),
+            Es => Pitch::new(NoteLetter::E, -1),
+            F => Pitch::new(NoteLetter::F, 0),
+            Fs => Pitch::new(NoteLetter::F, 1),
+            Gb => Pitch::new(NoteLetter::G, -1),
+            G => Pitch::new(NoteLetter::G, 0),
+            Gs => Pitch::new(NoteLetter::G, 1),
+            Ab => Pitch::new(NoteLetter::A, -1),
+            A => Pitch::new(NoteLetter::A, 0),
+            As => Pitch::new(NoteLetter::A, 1),
+            Bb => Pitch::new(NoteLetter::B, -1),
+            B => Pitch::new(NoteLetter::B, 0),
+            Cb => Pitch::new(NoteLetter::C, -1),
         }
     }
 }

--- a/src/note/pitch_symbol.rs
+++ b/src/note/pitch_symbol.rs
@@ -1,4 +1,4 @@
-use crate::note::{Pitch, pitch};
+use crate::note::{Pitch, pitch, NoteLetter};
 
 /// All possible pitches with accidentals.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -21,25 +21,25 @@ impl From<PitchSymbol> for Pitch {
     fn from(symbol: PitchSymbol) -> Self {
         use PitchSymbol::*;
         match symbol {
-            Bs => pitch(NoteSymbol::B, 1),
-            C => pitch(NoteSymbol::C, 0),
-            Cs => pitch(NoteSymbol:C, 1),
-            Db => pitch(NoteSymbol::D, -1),
-            D => pitch(NoteSymbol::D, 0),
-            Ds => pitch(NoteSymbol::D, 1),
-            Eb => pitch(NoteSymbol::E, -1),
-            E => pitch(NoteSymbol::E, 0),
-            Es => pitch(NoteSymbol::E, -1),
-            F => pitch(NoteSymbol::F, 0),
-            Fs => pitch(NoteSymbol::F, 1),
-            Gb => pitch(NoteSymbol::G, -1),
-            G => pitch(NoteSymbol::G, 0),
-            Gs => pitch(NoteSymbol::G, 1),
-            Ab => pitch(NoteSymbol::A, -1),
-            A => pitch(NoteSymbol::A, 0),
-            As => pitch(NoteSymbol::A, 1),
-            Bb => pitch(NoteSymbol::B, -1),
-            B => pitch(NoteSymbol::B, 0),
+            Bs => pitch(NoteLetter::B, 1),
+            C => pitch(NoteLetter::C, 0),
+            Cs => pitch(NoteLetter::C, 1),
+            Db => pitch(NoteLetter::D, -1),
+            D => pitch(NoteLetter::D, 0),
+            Ds => pitch(NoteLetter::D, 1),
+            Eb => pitch(NoteLetter::E, -1),
+            E => pitch(NoteLetter::E, 0),
+            Es => pitch(NoteLetter::E, -1),
+            F => pitch(NoteLetter::F, 0),
+            Fs => pitch(NoteLetter::F, 1),
+            Gb => pitch(NoteLetter::G, -1),
+            G => pitch(NoteLetter::G, 0),
+            Gs => pitch(NoteLetter::G, 1),
+            Ab => pitch(NoteLetter::A, -1),
+            A => pitch(NoteLetter::A, 0),
+            As => pitch(NoteLetter::A, 1),
+            Bb => pitch(NoteLetter::B, -1),
+            B => pitch(NoteLetter::B, 0),
         }
     }
 }

--- a/src/note/pitch_symbol.rs
+++ b/src/note/pitch_symbol.rs
@@ -1,0 +1,45 @@
+use crate::note::{Pitch, pitch};
+
+/// All possible pitches with accidentals.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PitchSymbol {
+    Bs, C,
+    Cs, Db,
+    D,
+    Ds, Eb,
+    E,
+    Es, F,
+    Fs, Gb,
+    G,
+    Gs, Ab,
+    A,
+    As, Bb,
+    B,
+}
+
+impl From<PitchSymbol> for Pitch {
+    fn from(symbol: PitchSymbol) -> Self {
+        use PitchSymbol::*;
+        match symbol {
+            Bs => pitch(NoteSymbol::B, 1),
+            C => pitch(NoteSymbol::C, 0),
+            Cs => pitch(NoteSymbol:C, 1),
+            Db => pitch(NoteSymbol::D, -1),
+            D => pitch(NoteSymbol::D, 0),
+            Ds => pitch(NoteSymbol::D, 1),
+            Eb => pitch(NoteSymbol::E, -1),
+            E => pitch(NoteSymbol::E, 0),
+            Es => pitch(NoteSymbol::E, -1),
+            F => pitch(NoteSymbol::F, 0),
+            Fs => pitch(NoteSymbol::F, 1),
+            Gb => pitch(NoteSymbol::G, -1),
+            G => pitch(NoteSymbol::G, 0),
+            Gs => pitch(NoteSymbol::G, 1),
+            Ab => pitch(NoteSymbol::A, -1),
+            A => pitch(NoteSymbol::A, 0),
+            As => pitch(NoteSymbol::A, 1),
+            Bb => pitch(NoteSymbol::B, -1),
+            B => pitch(NoteSymbol::B, 0),
+        }
+    }
+}

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -1,5 +1,5 @@
 use crate::interval::Interval;
-use crate::note::{Note, Notes, PitchClass};
+use crate::note::{Note, Notes, Pitch, NoteLetter};
 use crate::scale::errors::ScaleError;
 use crate::scale::{Mode, ScaleType};
 use strum_macros::Display;
@@ -15,7 +15,7 @@ pub enum Direction {
 #[derive(Debug, Clone)]
 pub struct Scale {
     /// The root note of the scale.
-    pub tonic: PitchClass,
+    pub tonic: Pitch,
     /// The octave of the root note of the scale.
     pub octave: u8,
     /// The type of scale (diatonic, melodic minor, harmonic minor).
@@ -32,7 +32,7 @@ impl Scale {
     /// Create a new scale with a given direction.
     pub fn new(
         scale_type: ScaleType,
-        tonic: PitchClass,
+        tonic: Pitch,
         octave: u8,
         mode: Option<Mode>,
         direction: Direction,
@@ -55,7 +55,7 @@ impl Scale {
 
     /// Parse a scale from a regex.
     pub fn from_regex_in_direction(string: &str, direction: Direction) -> Result<Self, ScaleError> {
-        let (tonic, tonic_match) = PitchClass::from_regex(&string.trim())?;
+        let (tonic, tonic_match) = Pitch::from_regex(&string.trim())?;
         let mode_string = &string[tonic_match.end()..].trim();
         let (mode, _) = Mode::from_regex(mode_string)?;
         let scale_type = ScaleType::from_mode(mode);
@@ -107,7 +107,7 @@ impl Notes for Scale {
 impl Default for Scale {
     fn default() -> Self {
         Scale {
-            tonic: PitchClass::C,
+            tonic: Pitch { letter: NoteLetter::C, accidental: 0 },
             octave: 0,
             scale_type: ScaleType::Diatonic,
             mode: Some(Mode::Ionian),

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -75,7 +75,7 @@ impl Notes for Scale {
         use Mode::*;
         let root_note = Note {
             octave: self.octave,
-            pitch_class: self.tonic,
+            pitch: self.tonic,
         };
 
         let mut intervals_clone = self.intervals.clone();

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -36,7 +36,7 @@ mod chord_tests {
                     &symbols,
                     Chord::with_inversion(Pitch::from(chord.0), chord.1, chord.2, inversion as u8).notes(),
                 );
-                classes.rotate_left(1);
+                symbols.rotate_left(1);
             }
         }
     }
@@ -53,7 +53,7 @@ mod chord_tests {
         ];
         for inversion in 0..octaves[0].len() {
             let notes =
-                Chord::with_inversion(chord_desc.0, chord_desc.1, chord_desc.2, inversion as u8)
+                Chord::with_inversion(Pitch::from(chord_desc.0), chord_desc.1, chord_desc.2, inversion as u8)
                     .notes();
             assert_eq!(
                 notes

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -1,10 +1,10 @@
 extern crate rust_music_theory as theory;
 use theory::chord::{Number::*, Quality::*, *};
-use theory::note::{PitchClass::*, *};
+use theory::note::{PitchSymbol::*, *};
 
-fn assert_notes(pitches: &[PitchClass], notes: Vec<Note>) {
-    for (i, pitch) in pitches.iter().enumerate() {
-        assert_eq!(*pitch, notes[i].pitch_class);
+fn assert_notes(symbols: &[PitchSymbol], notes: Vec<Note>) {
+    for (i, symbol) in symbols.iter().enumerate() {
+        assert_eq!(Pitch::from(*symbol), notes[i].pitch);
     }
 }
 
@@ -30,11 +30,11 @@ mod chord_tests {
         ];
 
         for (chord, pitches) in chord_tuples.iter() {
-            let classes = &mut pitches.clone();
+            let symbols = &mut pitches.clone();
             for inversion in 0..pitches.len() {
                 assert_notes(
-                    &classes,
-                    Chord::with_inversion(chord.0, chord.1, chord.2, inversion as u8).notes(),
+                    &symbols,
+                    Chord::with_inversion(Pitch::from(chord.0), chord.1, chord.2, inversion as u8).notes(),
                 );
                 classes.rotate_left(1);
             }

--- a/tests/chord/test_regex.rs
+++ b/tests/chord/test_regex.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 use theory::chord::{Chord, Number, Number::*, Quality, Quality::*};
-use theory::note::{Pitch, NoteLetter::*, pitch};
+use theory::note::{Pitch, NoteLetter::*};
 
 fn assert_chords(table: Vec<(&str, Pitch, Quality, Number)>) {
     for (string, pitch, quality, number) in table {
@@ -18,17 +18,17 @@ mod chord_regex_tests {
     #[test]
     fn test_major() {
         let table = vec![
-            ("C Major", pitch(C, 0), Major, Triad),
-            ("E MAJOR", pitch(E, 0), Major, Triad),
-            ("C Maj", pitch(C, 0), Major, Triad),
-            ("Cb MAJ", pitch(C, -1), Major, Triad),
-            ("Cb MAJ Seventh", pitch(C, -1), Major, Seventh),
-            ("C M", pitch(C, 0), Major, Triad),
-            ("C MaJ Triad", pitch(C, 0), Major, Triad),
-            ("C Major Seventh", pitch(C, 0), Major, Seventh),
-            ("C M Ninth", pitch(C, 0), Major, Ninth),
-            ("C M eleventh", pitch(C, 0), Major, Eleventh),
-            ("C M ThirTeenth", pitch(C, 0), Major, Thirteenth),
+            ("C Major", Pitch::new(C, 0), Major, Triad),
+            ("E MAJOR", Pitch::new(E, 0), Major, Triad),
+            ("C Maj", Pitch::new(C, 0), Major, Triad),
+            ("Cb MAJ", Pitch::new(C, -1), Major, Triad),
+            ("Cb MAJ Seventh", Pitch::new(C, -1), Major, Seventh),
+            ("C M", Pitch::new(C, 0), Major, Triad),
+            ("C MaJ Triad", Pitch::new(C, 0), Major, Triad),
+            ("C Major Seventh", Pitch::new(C, 0), Major, Seventh),
+            ("C M Ninth", Pitch::new(C, 0), Major, Ninth),
+            ("C M eleventh", Pitch::new(C, 0), Major, Eleventh),
+            ("C M ThirTeenth", Pitch::new(C, 0), Major, Thirteenth),
         ];
 
         assert_chords(table);
@@ -37,17 +37,17 @@ mod chord_regex_tests {
     #[test]
     fn test_minor() {
         let table = vec![
-            ("C Minor", pitch(C, 0), Minor, Triad),
-            ("E MINOR", pitch(E, 0), Minor, Triad),
-            ("C Min", pitch(C, 0), Minor, Triad),
-            ("Cb MIN", pitch(C, -1), Minor, Triad),
-            ("Cb MIN Seventh", pitch(C, -1), Minor, Seventh),
-            ("C m", pitch(C, 0), Minor, Triad),
-            ("C MiN Triad", pitch(C, 0), Minor, Triad),
-            ("C Minor Seventh", pitch(C, 0), Minor, Seventh),
-            ("C m Ninth", pitch(C, 0), Minor, Ninth),
-            ("C#m Eleventh", pitch(C, 1), Minor, Eleventh),
-            ("Dsm Thirteenth", pitch(D, 1), Minor, Thirteenth),
+            ("C Minor", Pitch::new(C, 0), Minor, Triad),
+            ("E MINOR", Pitch::new(E, 0), Minor, Triad),
+            ("C Min", Pitch::new(C, 0), Minor, Triad),
+            ("Cb MIN", Pitch::new(C, -1), Minor, Triad),
+            ("Cb MIN Seventh", Pitch::new(C, -1), Minor, Seventh),
+            ("C m", Pitch::new(C, 0), Minor, Triad),
+            ("C MiN Triad", Pitch::new(C, 0), Minor, Triad),
+            ("C Minor Seventh", Pitch::new(C, 0), Minor, Seventh),
+            ("C m Ninth", Pitch::new(C, 0), Minor, Ninth),
+            ("C#m Eleventh", Pitch::new(C, 1), Minor, Eleventh),
+            ("Dsm Thirteenth", Pitch::new(D, 1), Minor, Thirteenth),
         ];
 
         assert_chords(table);
@@ -56,17 +56,17 @@ mod chord_regex_tests {
     #[test]
     fn test_augmented() {
         let table = vec![
-            ("C augmented", pitch(C, 0), Augmented, Triad),
-            ("E Augmented", pitch(E, 0), Augmented, Triad),
-            ("C augmented", pitch(C, 0), Augmented, Triad),
-            ("Cb augmented", pitch(C, -1), Augmented, Triad),
-            ("Cb augmented seventh", pitch(C, -1), Augmented, Seventh),
-            ("C augmented", pitch(C, 0), Augmented, Triad),
-            ("C augmented Triad", pitch(C, 0), Augmented, Triad),
-            ("C Augmented Seventh", pitch(C, 0), Augmented, Seventh),
-            ("C Augmented Ninth", pitch(C, 0), Augmented, Ninth),
-            ("C# augmented Eleventh", pitch(C, 1), Augmented, Eleventh),
-            ("Ds augmented Thirteenth", pitch(D, 1), Augmented, Thirteenth),
+            ("C augmented", Pitch::new(C, 0), Augmented, Triad),
+            ("E Augmented", Pitch::new(E, 0), Augmented, Triad),
+            ("C augmented", Pitch::new(C, 0), Augmented, Triad),
+            ("Cb augmented", Pitch::new(C, -1), Augmented, Triad),
+            ("Cb augmented seventh", Pitch::new(C, -1), Augmented, Seventh),
+            ("C augmented", Pitch::new(C, 0), Augmented, Triad),
+            ("C augmented Triad", Pitch::new(C, 0), Augmented, Triad),
+            ("C Augmented Seventh", Pitch::new(C, 0), Augmented, Seventh),
+            ("C Augmented Ninth", Pitch::new(C, 0), Augmented, Ninth),
+            ("C# augmented Eleventh", Pitch::new(C, 1), Augmented, Eleventh),
+            ("Ds augmented Thirteenth", Pitch::new(D, 1), Augmented, Thirteenth),
         ];
 
         assert_chords(table);
@@ -75,17 +75,17 @@ mod chord_regex_tests {
     #[test]
     fn test_diminished() {
         let table = vec![
-            ("C Diminished", pitch(C, 0), Diminished, Triad),
-            ("E Diminished", pitch(E, 0), Diminished, Triad),
-            ("C Diminished", pitch(C, 0), Diminished, Triad),
-            ("Cb Diminished", pitch(C, -1), Diminished, Triad),
-            ("Cb Diminished seventh", pitch(C, -1), Diminished, Seventh),
-            ("C Diminished", pitch(C, 0), Diminished, Triad),
-            ("C Diminished Triad", pitch(C, 0), Diminished, Triad),
-            ("C Diminished Seventh", pitch(C, 0), Diminished, Seventh),
-            ("C Diminished Ninth", pitch(C, 0), Diminished, Ninth),
-            ("C# Diminished Eleventh", pitch(C, 1), Diminished, Eleventh),
-            ("Ds Diminished Thirteenth", pitch(D, 1), Diminished, Thirteenth),
+            ("C Diminished", Pitch::new(C, 0), Diminished, Triad),
+            ("E Diminished", Pitch::new(E, 0), Diminished, Triad),
+            ("C Diminished", Pitch::new(C, 0), Diminished, Triad),
+            ("Cb Diminished", Pitch::new(C, -1), Diminished, Triad),
+            ("Cb Diminished seventh", Pitch::new(C, -1), Diminished, Seventh),
+            ("C Diminished", Pitch::new(C, 0), Diminished, Triad),
+            ("C Diminished Triad", Pitch::new(C, 0), Diminished, Triad),
+            ("C Diminished Seventh", Pitch::new(C, 0), Diminished, Seventh),
+            ("C Diminished Ninth", Pitch::new(C, 0), Diminished, Ninth),
+            ("C# Diminished Eleventh", Pitch::new(C, 1), Diminished, Eleventh),
+            ("Ds Diminished Thirteenth", Pitch::new(D, 1), Diminished, Thirteenth),
         ];
 
         assert_chords(table);
@@ -94,19 +94,19 @@ mod chord_regex_tests {
     #[test]
     fn test_half_diminished() {
         let table = vec![
-            ("C Half Diminished", pitch(C, 0), HalfDiminished, Triad),
-            ("E halfdiminished", pitch(E, 0), HalfDiminished, Triad),
-            ("C half diminished", pitch(C, 0), HalfDiminished, Triad),
-            ("Cb HALFDIMINISHED", pitch(C, -1), HalfDiminished, Triad),
-            ("Cb HalfDiminished seventh", pitch(C, -1), HalfDiminished, Seventh),
-            ("C HalfDiminished", pitch(C, 0), HalfDiminished, Triad),
-            ("C HalfDiminished Triad", pitch(C, 0), HalfDiminished, Triad),
-            ("C HalfDiminished Seventh", pitch(C, 0), HalfDiminished, Seventh),
-            ("C HalfDiminished Ninth", pitch(C, 0), HalfDiminished, Ninth),
-            ("C# HalfDiminished Eleventh", pitch(C, 1), HalfDiminished, Eleventh),
+            ("C Half Diminished", Pitch::new(C, 0), HalfDiminished, Triad),
+            ("E halfdiminished", Pitch::new(E, 0), HalfDiminished, Triad),
+            ("C half diminished", Pitch::new(C, 0), HalfDiminished, Triad),
+            ("Cb HALFDIMINISHED", Pitch::new(C, -1), HalfDiminished, Triad),
+            ("Cb HalfDiminished seventh", Pitch::new(C, -1), HalfDiminished, Seventh),
+            ("C HalfDiminished", Pitch::new(C, 0), HalfDiminished, Triad),
+            ("C HalfDiminished Triad", Pitch::new(C, 0), HalfDiminished, Triad),
+            ("C HalfDiminished Seventh", Pitch::new(C, 0), HalfDiminished, Seventh),
+            ("C HalfDiminished Ninth", Pitch::new(C, 0), HalfDiminished, Ninth),
+            ("C# HalfDiminished Eleventh", Pitch::new(C, 1), HalfDiminished, Eleventh),
             (
                 "Ds HalfDiminished Thirteenth",
-                pitch(D, 1),
+                Pitch::new(D, 1),
                 HalfDiminished,
                 Thirteenth,
             ),
@@ -118,17 +118,17 @@ mod chord_regex_tests {
     #[test]
     fn test_dominant() {
         let table = vec![
-            ("C dominant", pitch(C, 0), Dominant, Triad),
-            ("E DOMINANT", pitch(E, 0), Dominant, Triad),
-            ("C DOmInAnT", pitch(C, 0), Dominant, Triad),
-            ("Cb Dominant", pitch(C, -1), Dominant, Triad),
-            ("Cb Dominant seventh", pitch(C, -1), Dominant, Seventh),
-            ("C Dominant", pitch(C, 0), Dominant, Triad),
-            ("C Dominant Triad", pitch(C, 0), Dominant, Triad),
-            ("C Dominant Seventh", pitch(C, 0), Dominant, Seventh),
-            ("C Dominant Ninth", pitch(C, 0), Dominant, Ninth),
-            ("C# Dominant Eleventh", pitch(C, 1), Dominant, Eleventh),
-            ("Ds Dominant Thirteenth", pitch(D, 1), Dominant, Thirteenth),
+            ("C dominant", Pitch::new(C, 0), Dominant, Triad),
+            ("E DOMINANT", Pitch::new(E, 0), Dominant, Triad),
+            ("C DOmInAnT", Pitch::new(C, 0), Dominant, Triad),
+            ("Cb Dominant", Pitch::new(C, -1), Dominant, Triad),
+            ("Cb Dominant seventh", Pitch::new(C, -1), Dominant, Seventh),
+            ("C Dominant", Pitch::new(C, 0), Dominant, Triad),
+            ("C Dominant Triad", Pitch::new(C, 0), Dominant, Triad),
+            ("C Dominant Seventh", Pitch::new(C, 0), Dominant, Seventh),
+            ("C Dominant Ninth", Pitch::new(C, 0), Dominant, Ninth),
+            ("C# Dominant Eleventh", Pitch::new(C, 1), Dominant, Eleventh),
+            ("Ds Dominant Thirteenth", Pitch::new(D, 1), Dominant, Thirteenth),
         ];
 
         assert_chords(table);
@@ -137,11 +137,11 @@ mod chord_regex_tests {
     #[test]
     fn test_suspended() {
         let table = vec![
-            ("C sus2", pitch(C, 0), Suspended2, Triad),
-            ("E sus2 triad", pitch(E, 0), Suspended2, Triad),
-            ("C sus4", pitch(C, 0), Suspended4, Triad),
-            ("Cb suspended4", pitch(C, -1), Suspended4, Triad),
-            ("Cb suspended2", pitch(C, -1), Suspended2, Triad),
+            ("C sus2", Pitch::new(C, 0), Suspended2, Triad),
+            ("E sus2 triad", Pitch::new(E, 0), Suspended2, Triad),
+            ("C sus4", Pitch::new(C, 0), Suspended4, Triad),
+            ("Cb suspended4", Pitch::new(C, -1), Suspended4, Triad),
+            ("Cb suspended2", Pitch::new(C, -1), Suspended2, Triad),
         ];
 
         assert_chords(table);

--- a/tests/chord/test_regex.rs
+++ b/tests/chord/test_regex.rs
@@ -1,8 +1,8 @@
 extern crate rust_music_theory as theory;
 use theory::chord::{Chord, Number, Number::*, Quality, Quality::*};
-use theory::note::{PitchClass, PitchClass::*};
+use theory::note::{Pitch, NoteLetter::*, pitch};
 
-fn assert_chords(table: Vec<(&str, PitchClass, Quality, Number)>) {
+fn assert_chords(table: Vec<(&str, Pitch, Quality, Number)>) {
     for (string, pitch, quality, number) in table {
         let chord = Chord::from_regex(string).unwrap();
         assert_eq!(chord.quality, quality);
@@ -18,17 +18,17 @@ mod chord_regex_tests {
     #[test]
     fn test_major() {
         let table = vec![
-            ("C Major", C, Major, Triad),
-            ("E MAJOR", E, Major, Triad),
-            ("C Maj", C, Major, Triad),
-            ("Cb MAJ", B, Major, Triad),
-            ("Cb MAJ Seventh", B, Major, Seventh),
-            ("C M", C, Major, Triad),
-            ("C MaJ Triad", C, Major, Triad),
-            ("C Major Seventh", C, Major, Seventh),
-            ("C M Ninth", C, Major, Ninth),
-            ("C M eleventh", C, Major, Eleventh),
-            ("C M ThirTeenth", C, Major, Thirteenth),
+            ("C Major", pitch(C, 0), Major, Triad),
+            ("E MAJOR", pitch(E, 0), Major, Triad),
+            ("C Maj", pitch(C, 0), Major, Triad),
+            ("Cb MAJ", pitch(C, -1), Major, Triad),
+            ("Cb MAJ Seventh", pitch(C, -1), Major, Seventh),
+            ("C M", pitch(C, 0), Major, Triad),
+            ("C MaJ Triad", pitch(C, 0), Major, Triad),
+            ("C Major Seventh", pitch(C, 0), Major, Seventh),
+            ("C M Ninth", pitch(C, 0), Major, Ninth),
+            ("C M eleventh", pitch(C, 0), Major, Eleventh),
+            ("C M ThirTeenth", pitch(C, 0), Major, Thirteenth),
         ];
 
         assert_chords(table);
@@ -37,17 +37,17 @@ mod chord_regex_tests {
     #[test]
     fn test_minor() {
         let table = vec![
-            ("C Minor", C, Minor, Triad),
-            ("E MINOR", E, Minor, Triad),
-            ("C Min", C, Minor, Triad),
-            ("Cb MIN", B, Minor, Triad),
-            ("Cb MIN Seventh", B, Minor, Seventh),
-            ("C m", C, Minor, Triad),
-            ("C MiN Triad", C, Minor, Triad),
-            ("C Minor Seventh", C, Minor, Seventh),
-            ("C m Ninth", C, Minor, Ninth),
-            ("C#m Eleventh", Cs, Minor, Eleventh),
-            ("Dsm Thirteenth", Ds, Minor, Thirteenth),
+            ("C Minor", pitch(C, 0), Minor, Triad),
+            ("E MINOR", pitch(E, 0), Minor, Triad),
+            ("C Min", pitch(C, 0), Minor, Triad),
+            ("Cb MIN", pitch(C, -1), Minor, Triad),
+            ("Cb MIN Seventh", pitch(C, -1), Minor, Seventh),
+            ("C m", pitch(C, 0), Minor, Triad),
+            ("C MiN Triad", pitch(C, 0), Minor, Triad),
+            ("C Minor Seventh", pitch(C, 0), Minor, Seventh),
+            ("C m Ninth", pitch(C, 0), Minor, Ninth),
+            ("C#m Eleventh", pitch(C, 1), Minor, Eleventh),
+            ("Dsm Thirteenth", pitch(D, 1), Minor, Thirteenth),
         ];
 
         assert_chords(table);
@@ -56,17 +56,17 @@ mod chord_regex_tests {
     #[test]
     fn test_augmented() {
         let table = vec![
-            ("C augmented", C, Augmented, Triad),
-            ("E Augmented", E, Augmented, Triad),
-            ("C augmented", C, Augmented, Triad),
-            ("Cb augmented", B, Augmented, Triad),
-            ("Cb augmented seventh", B, Augmented, Seventh),
-            ("C augmented", C, Augmented, Triad),
-            ("C augmented Triad", C, Augmented, Triad),
-            ("C Augmented Seventh", C, Augmented, Seventh),
-            ("C Augmented Ninth", C, Augmented, Ninth),
-            ("C# augmented Eleventh", Cs, Augmented, Eleventh),
-            ("Ds augmented Thirteenth", Ds, Augmented, Thirteenth),
+            ("C augmented", pitch(C, 0), Augmented, Triad),
+            ("E Augmented", pitch(E, 0), Augmented, Triad),
+            ("C augmented", pitch(C, 0), Augmented, Triad),
+            ("Cb augmented", pitch(C, -1), Augmented, Triad),
+            ("Cb augmented seventh", pitch(C, -1), Augmented, Seventh),
+            ("C augmented", pitch(C, 0), Augmented, Triad),
+            ("C augmented Triad", pitch(C, 0), Augmented, Triad),
+            ("C Augmented Seventh", pitch(C, 0), Augmented, Seventh),
+            ("C Augmented Ninth", pitch(C, 0), Augmented, Ninth),
+            ("C# augmented Eleventh", pitch(C, 1), Augmented, Eleventh),
+            ("Ds augmented Thirteenth", pitch(D, 1), Augmented, Thirteenth),
         ];
 
         assert_chords(table);
@@ -75,17 +75,17 @@ mod chord_regex_tests {
     #[test]
     fn test_diminished() {
         let table = vec![
-            ("C Diminished", C, Diminished, Triad),
-            ("E Diminished", E, Diminished, Triad),
-            ("C Diminished", C, Diminished, Triad),
-            ("Cb Diminished", B, Diminished, Triad),
-            ("Cb Diminished seventh", B, Diminished, Seventh),
-            ("C Diminished", C, Diminished, Triad),
-            ("C Diminished Triad", C, Diminished, Triad),
-            ("C Diminished Seventh", C, Diminished, Seventh),
-            ("C Diminished Ninth", C, Diminished, Ninth),
-            ("C# Diminished Eleventh", Cs, Diminished, Eleventh),
-            ("Ds Diminished Thirteenth", Ds, Diminished, Thirteenth),
+            ("C Diminished", pitch(C, 0), Diminished, Triad),
+            ("E Diminished", pitch(E, 0), Diminished, Triad),
+            ("C Diminished", pitch(C, 0), Diminished, Triad),
+            ("Cb Diminished", pitch(C, -1), Diminished, Triad),
+            ("Cb Diminished seventh", pitch(C, -1), Diminished, Seventh),
+            ("C Diminished", pitch(C, 0), Diminished, Triad),
+            ("C Diminished Triad", pitch(C, 0), Diminished, Triad),
+            ("C Diminished Seventh", pitch(C, 0), Diminished, Seventh),
+            ("C Diminished Ninth", pitch(C, 0), Diminished, Ninth),
+            ("C# Diminished Eleventh", pitch(C, 1), Diminished, Eleventh),
+            ("Ds Diminished Thirteenth", pitch(D, 1), Diminished, Thirteenth),
         ];
 
         assert_chords(table);
@@ -94,19 +94,19 @@ mod chord_regex_tests {
     #[test]
     fn test_half_diminished() {
         let table = vec![
-            ("C Half Diminished", C, HalfDiminished, Triad),
-            ("E halfdiminished", E, HalfDiminished, Triad),
-            ("C half diminished", C, HalfDiminished, Triad),
-            ("Cb HALFDIMINISHED", B, HalfDiminished, Triad),
-            ("Cb HalfDiminished seventh", B, HalfDiminished, Seventh),
-            ("C HalfDiminished", C, HalfDiminished, Triad),
-            ("C HalfDiminished Triad", C, HalfDiminished, Triad),
-            ("C HalfDiminished Seventh", C, HalfDiminished, Seventh),
-            ("C HalfDiminished Ninth", C, HalfDiminished, Ninth),
-            ("C# HalfDiminished Eleventh", Cs, HalfDiminished, Eleventh),
+            ("C Half Diminished", pitch(C, 0), HalfDiminished, Triad),
+            ("E halfdiminished", pitch(E, 0), HalfDiminished, Triad),
+            ("C half diminished", pitch(C, 0), HalfDiminished, Triad),
+            ("Cb HALFDIMINISHED", pitch(C, -1), HalfDiminished, Triad),
+            ("Cb HalfDiminished seventh", pitch(C, -1), HalfDiminished, Seventh),
+            ("C HalfDiminished", pitch(C, 0), HalfDiminished, Triad),
+            ("C HalfDiminished Triad", pitch(C, 0), HalfDiminished, Triad),
+            ("C HalfDiminished Seventh", pitch(C, 0), HalfDiminished, Seventh),
+            ("C HalfDiminished Ninth", pitch(C, 0), HalfDiminished, Ninth),
+            ("C# HalfDiminished Eleventh", pitch(C, 1), HalfDiminished, Eleventh),
             (
                 "Ds HalfDiminished Thirteenth",
-                Ds,
+                pitch(D, 1),
                 HalfDiminished,
                 Thirteenth,
             ),
@@ -118,17 +118,17 @@ mod chord_regex_tests {
     #[test]
     fn test_dominant() {
         let table = vec![
-            ("C dominant", C, Dominant, Triad),
-            ("E DOMINANT", E, Dominant, Triad),
-            ("C DOmInAnT", C, Dominant, Triad),
-            ("Cb Dominant", B, Dominant, Triad),
-            ("Cb Dominant seventh", B, Dominant, Seventh),
-            ("C Dominant", C, Dominant, Triad),
-            ("C Dominant Triad", C, Dominant, Triad),
-            ("C Dominant Seventh", C, Dominant, Seventh),
-            ("C Dominant Ninth", C, Dominant, Ninth),
-            ("C# Dominant Eleventh", Cs, Dominant, Eleventh),
-            ("Ds Dominant Thirteenth", Ds, Dominant, Thirteenth),
+            ("C dominant", pitch(C, 0), Dominant, Triad),
+            ("E DOMINANT", pitch(E, 0), Dominant, Triad),
+            ("C DOmInAnT", pitch(C, 0), Dominant, Triad),
+            ("Cb Dominant", pitch(C, -1), Dominant, Triad),
+            ("Cb Dominant seventh", pitch(C, -1), Dominant, Seventh),
+            ("C Dominant", pitch(C, 0), Dominant, Triad),
+            ("C Dominant Triad", pitch(C, 0), Dominant, Triad),
+            ("C Dominant Seventh", pitch(C, 0), Dominant, Seventh),
+            ("C Dominant Ninth", pitch(C, 0), Dominant, Ninth),
+            ("C# Dominant Eleventh", pitch(C, 1), Dominant, Eleventh),
+            ("Ds Dominant Thirteenth", pitch(D, 1), Dominant, Thirteenth),
         ];
 
         assert_chords(table);
@@ -137,11 +137,11 @@ mod chord_regex_tests {
     #[test]
     fn test_suspended() {
         let table = vec![
-            ("C sus2", C, Suspended2, Triad),
-            ("E sus2 triad", E, Suspended2, Triad),
-            ("C sus4", C, Suspended4, Triad),
-            ("Cb suspended4", B, Suspended4, Triad),
-            ("Cb suspended2", B, Suspended2, Triad),
+            ("C sus2", pitch(C, 0), Suspended2, Triad),
+            ("E sus2 triad", pitch(E, 0), Suspended2, Triad),
+            ("C sus4", pitch(C, 0), Suspended4, Triad),
+            ("Cb suspended4", pitch(C, -1), Suspended4, Triad),
+            ("Cb suspended2", pitch(C, -1), Suspended2, Triad),
         ];
 
         assert_chords(table);

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 use theory::interval::Interval;
-use theory::note::{Note, Pitch::*};
+use theory::note::{Note, Pitch, PitchSymbol::*};
 
 #[cfg(test)]
 mod test_interval {
@@ -11,7 +11,7 @@ mod test_interval {
         let notes = vec![(C, 3), (D, 3), (E, 3), (Fs, 3), (Gs, 3), (As, 3), (C, 4)]
             .into_iter()
             .map(|note| Note {
-                pitch_class: note.0,
+                pitch: Pitch::from(note.0),
                 octave: note.1,
             })
             .collect::<Vec<Note>>();
@@ -19,7 +19,7 @@ mod test_interval {
         let major_second = Interval::from_semitone(2).unwrap();
         for i in 0..(notes.len() - 1) {
             let next_note = major_second.second_note_from(notes[i].clone());
-            assert_eq!(next_note.pitch_class, notes[i + 1].pitch_class);
+            assert_eq!(next_note.pitch, notes[i + 1].pitch);
             assert_eq!(next_note.octave, notes[i + 1].octave);
         }
     }
@@ -29,7 +29,7 @@ mod test_interval {
         let notes = vec![(C, 4), (As, 3), (Gs, 3), (Fs, 3), (E, 3), (D, 3), (C, 3)]
             .into_iter()
             .map(|note| Note {
-                pitch_class: note.0,
+                pitch: Pitch::from(note.0),
                 octave: note.1,
             })
             .collect::<Vec<Note>>();
@@ -37,7 +37,7 @@ mod test_interval {
         let major_second = Interval::from_semitone(2).unwrap();
         for i in 0..(notes.len() - 1) {
             let next_note = major_second.second_note_down_from(notes[i].clone());
-            assert_eq!(next_note.pitch_class, notes[i + 1].pitch_class);
+            assert_eq!(next_note.pitch, notes[i + 1].pitch);
             assert_eq!(next_note.octave, notes[i + 1].octave);
         }
     }
@@ -47,7 +47,7 @@ mod test_interval {
         let octave_interval = Interval::from_semitone(12).unwrap();
         for octave in 0..=8 {
             let note = Note {
-                pitch_class: C,
+                pitch: Pitch::from(C),
                 octave,
             };
             let next_note = octave_interval.second_note_from(note.clone());
@@ -60,7 +60,7 @@ mod test_interval {
         let octave_interval = Interval::from_semitone(12).unwrap();
         for octave in 8..=0 {
             let note = Note {
-                pitch_class: C,
+                pitch: Pitch::from(C),
                 octave,
             };
             let next_note = octave_interval.second_note_down_from(note.clone());

--- a/tests/interval/test_interval.rs
+++ b/tests/interval/test_interval.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 use theory::interval::Interval;
-use theory::note::{Note, PitchClass::*};
+use theory::note::{Note, Pitch::*};
 
 #[cfg(test)]
 mod test_interval {

--- a/tests/note/test_pitch.rs
+++ b/tests/note/test_pitch.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::{Pitch, NoteLetter::*, pitch};
+use theory::note::{Pitch, NoteLetter::*};
 
 #[cfg(test)]
 mod test_note {
@@ -8,27 +8,31 @@ mod test_note {
     #[test]
     fn test_pitch_from_str() {
         let table = vec![
-            ("Cb", pitch(C, -1)),
-            ("C#", pitch(C, 1)),
-            ("C♯", pitch(C, 1)),
-            ("D", pitch(D, 0)),
-            ("Db", pitch(D, -1)),
-            ("Ds", pitch(D, 1)),
-            ("E", pitch(E, 0)),
-            ("Es", pitch(E, 1)),
-            ("Eb", pitch(E, -1)),
-            ("F", pitch(F, 0)),
-            ("f", pitch(F, 0)),
-            ("Fb", pitch(F, -1)),
-            ("G", pitch(G, 0)),
-            ("Gb", pitch(G, -1)),
-            ("Gs", pitch(G, 1)),
-            ("A", pitch(A, 0)),
-            ("As", pitch(A, 1)),
-            ("Ab", pitch(A, -1)),
-            ("B", pitch(B, 0)),
-            ("B♯", pitch(B, 1)),
-            ("Bb", pitch(B, -1)),
+            ("Cb", Pitch::new(C, -1)),
+            ("C#", Pitch::new(C, 1)),
+            ("C♯#", Pitch::new(C, 2)),
+            ("D", Pitch::new(D, 0)),
+            ("Db", Pitch::new(D, -1)),
+            ("Dbb", Pitch::new(D, -2)),
+            ("Ds", Pitch::new(D, 1)),
+            ("E", Pitch::new(E, 0)),
+            ("Es", Pitch::new(E, 1)),
+            ("Eb", Pitch::new(E, -1)),
+            ("F", Pitch::new(F, 0)),
+            ("f", Pitch::new(F, 0)),
+            ("Fb", Pitch::new(F, -1)),
+            ("G", Pitch::new(G, 0)),
+            ("Gb", Pitch::new(G, -1)),
+            ("G♭b♭", Pitch::new(G, -3)),
+            ("Gs", Pitch::new(G, 1)),
+            ("Gs##s𝄪", Pitch::new(G, 6)),
+            ("Gs#♯", Pitch::new(G, 3)),
+            ("A", Pitch::new(A, 0)),
+            ("As", Pitch::new(A, 1)),
+            ("Ab", Pitch::new(A, -1)),
+            ("B", Pitch::new(B, 0)),
+            ("B♯", Pitch::new(B, 1)),
+            ("Bb", Pitch::new(B, -1)),
         ];
 
         for (string, pitch) in table {
@@ -39,20 +43,27 @@ mod test_note {
     }
 
     #[test]
+    fn test_pitch_from_str_err() {
+        for string in vec!["Ca", "Q", "Cb#", "B♯b#"] {
+            assert!(Pitch::from_str(string).is_none());
+        }
+    }
+
+    #[test]
     fn test_pitch_into_u8() {
         let table = vec![
-            (pitch(C, 0), 0),
-            (pitch(C, 1), 1),
-            (pitch(D, 0), 2),
-            (pitch(D, 1), 3),
-            (pitch(E, 0), 4),
-            (pitch(F, 0), 5),
-            (pitch(F, 1), 6),
-            (pitch(G, 0), 7),
-            (pitch(G, 1), 8),
-            (pitch(A, 0), 9),
-            (pitch(A, 1), 10),
-            (pitch(B, 0), 11),
+            (Pitch::new(C, 0), 0),
+            (Pitch::new(C, 1), 1),
+            (Pitch::new(D, 0), 2),
+            (Pitch::new(D, 1), 3),
+            (Pitch::new(E, 0), 4),
+            (Pitch::new(F, 0), 5),
+            (Pitch::new(F, 1), 6),
+            (Pitch::new(G, 0), 7),
+            (Pitch::new(G, 1), 8),
+            (Pitch::new(A, 0), 9),
+            (Pitch::new(A, 1), 10),
+            (Pitch::new(B, 0), 11),
         ];
 
         for (pitch, number) in table {
@@ -63,8 +74,8 @@ mod test_note {
 
     #[test]
     fn test_pitch_format() {
-        assert_eq!(format!("{}", pitch(C,2)), "C##");
-        assert_eq!(format!("{}", pitch(C,-2)), "Cbb");
-        assert_eq!(format!("{}", pitch(C,0)), "C");
+        assert_eq!(format!("{}", Pitch::new(C,2)), "C##");
+        assert_eq!(format!("{}", Pitch::new(C,-2)), "Cbb");
+        assert_eq!(format!("{}", Pitch::new(C,0)), "C");
     }
 }

--- a/tests/note/test_pitch.rs
+++ b/tests/note/test_pitch.rs
@@ -60,4 +60,11 @@ mod test_note {
             assert_eq!(n, number);
         }
     }
+
+    #[test]
+    fn test_pitch_format() {
+        assert_eq!(format!("{}", pitch(C,2)), "C##");
+        assert_eq!(format!("{}", pitch(C,-2)), "Cbb");
+        assert_eq!(format!("{}", pitch(C,0)), "C");
+    }
 }

--- a/tests/note/test_pitch.rs
+++ b/tests/note/test_pitch.rs
@@ -6,7 +6,7 @@ mod test_note {
     use super::*;
 
     #[test]
-    fn test_pitch_class_from_str() {
+    fn test_pitch_from_str() {
         let table = vec![
             ("Cb", pitch(C, -1)),
             ("C#", pitch(C, 1)),
@@ -31,15 +31,15 @@ mod test_note {
             ("Bb", pitch(B, -1)),
         ];
 
-        for (string, pitch_class) in table {
+        for (string, pitch) in table {
             let p = Pitch::from_str(string).unwrap();
-            assert_eq!(p, pitch_class);
-            assert_eq!(string.parse::<Pitch>().unwrap(), pitch_class);
+            assert_eq!(p, pitch);
+            assert_eq!(string.parse::<Pitch>().unwrap(), pitch);
         }
     }
 
     #[test]
-    fn test_pitch_class_into_u8() {
+    fn test_pitch_into_u8() {
         let table = vec![
             (pitch(C, 0), 0),
             (pitch(C, 1), 1),
@@ -55,8 +55,8 @@ mod test_note {
             (pitch(B, 0), 11),
         ];
 
-        for (pitch_class, number) in table {
-            let n = pitch_class.into_u8();
+        for (pitch, number) in table {
+            let n = pitch.into_u8();
             assert_eq!(n, number);
         }
     }

--- a/tests/note/test_pitch_class.rs
+++ b/tests/note/test_pitch_class.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::{PitchClass, PitchClass::*};
+use theory::note::{Pitch, NoteLetter::*, pitch};
 
 #[cfg(test)]
 mod test_note {
@@ -8,52 +8,51 @@ mod test_note {
     #[test]
     fn test_pitch_class_from_str() {
         let table = vec![
-            ("Cb", B),
-            ("C#", Cs),
-            ("C#", Cs),
-            ("C♯", Cs),
-            ("D", D),
-            ("Db", Cs),
-            ("Ds", Ds),
-            ("E", E),
-            ("Es", F),
-            ("Eb", Ds),
-            ("F", F),
-            ("f", F),
-            ("Fb", E),
-            ("G", G),
-            ("Gb", Fs),
-            ("Gs", Gs),
-            ("A", A),
-            ("As", As),
-            ("Ab", Gs),
-            ("B", B),
-            ("B♯", C),
-            ("Bb", As),
+            ("Cb", pitch(C, -1)),
+            ("C#", pitch(C, 1)),
+            ("C♯", pitch(C, 1)),
+            ("D", pitch(D, 0)),
+            ("Db", pitch(D, -1)),
+            ("Ds", pitch(D, 1)),
+            ("E", pitch(E, 0)),
+            ("Es", pitch(E, 1)),
+            ("Eb", pitch(E, -1)),
+            ("F", pitch(F, 0)),
+            ("f", pitch(F, 0)),
+            ("Fb", pitch(F, -1)),
+            ("G", pitch(G, 0)),
+            ("Gb", pitch(G, -1)),
+            ("Gs", pitch(G, 1)),
+            ("A", pitch(A, 0)),
+            ("As", pitch(A, 1)),
+            ("Ab", pitch(A, -1)),
+            ("B", pitch(B, 0)),
+            ("B♯", pitch(B, 1)),
+            ("Bb", pitch(B, -1)),
         ];
 
         for (string, pitch_class) in table {
-            let p = PitchClass::from_str(string).unwrap();
+            let p = Pitch::from_str(string).unwrap();
             assert_eq!(p, pitch_class);
-            assert_eq!(string.parse::<PitchClass>().unwrap(), pitch_class);
+            assert_eq!(string.parse::<Pitch>().unwrap(), pitch_class);
         }
     }
 
     #[test]
     fn test_pitch_class_into_u8() {
         let table = vec![
-            (C, 0),
-            (Cs, 1),
-            (D, 2),
-            (Ds, 3),
-            (E, 4),
-            (F, 5),
-            (Fs, 6),
-            (G, 7),
-            (Gs, 8),
-            (A, 9),
-            (As, 10),
-            (B, 11),
+            (pitch(C, 0), 0),
+            (pitch(C, 1), 1),
+            (pitch(D, 0), 2),
+            (pitch(D, 1), 3),
+            (pitch(E, 0), 4),
+            (pitch(F, 0), 5),
+            (pitch(F, 1), 6),
+            (pitch(G, 0), 7),
+            (pitch(G, 1), 8),
+            (pitch(A, 0), 9),
+            (pitch(A, 1), 10),
+            (pitch(B, 0), 11),
         ];
 
         for (pitch_class, number) in table {

--- a/tests/scale/test_regex.rs
+++ b/tests/scale/test_regex.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::{NoteLetter::*, pitch};
+use theory::note::{NoteLetter::*, Pitch};
 use theory::scale::{Mode, Scale, ScaleType};
 
 #[cfg(test)]
@@ -9,26 +9,26 @@ mod chord_regex_tests {
     #[test]
     fn test_all_scales() {
         let table = vec![
-            ("C Major", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
-            ("CM", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
-            ("C Maj", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
-            ("C MAJOR", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
-            ("As locrian", pitch(A, 1), ScaleType::Diatonic, Mode::Locrian),
-            ("Bs phrygian", pitch(B, 1), ScaleType::Diatonic, Mode::Phrygian),
-            ("E lydian", pitch(E, 0), ScaleType::Diatonic, Mode::Lydian),
-            ("F dorian", pitch(F, 0), ScaleType::Diatonic, Mode::Dorian),
-            ("Gb mixolydian", pitch(G, -1), ScaleType::Diatonic, Mode::Mixolydian),
-            ("B MAJOR", pitch(B, 0), ScaleType::Diatonic, Mode::Ionian),
-            ("Bb MAJOR", pitch(B, -1), ScaleType::Diatonic, Mode::Ionian),
+            ("C Major", Pitch::new(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("CM", Pitch::new(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("C Maj", Pitch::new(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("C MAJOR", Pitch::new(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("As locrian", Pitch::new(A, 1), ScaleType::Diatonic, Mode::Locrian),
+            ("Bs phrygian", Pitch::new(B, 1), ScaleType::Diatonic, Mode::Phrygian),
+            ("E lydian", Pitch::new(E, 0), ScaleType::Diatonic, Mode::Lydian),
+            ("F dorian", Pitch::new(F, 0), ScaleType::Diatonic, Mode::Dorian),
+            ("Gb mixolydian", Pitch::new(G, -1), ScaleType::Diatonic, Mode::Mixolydian),
+            ("B MAJOR", Pitch::new(B, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("Bb MAJOR", Pitch::new(B, -1), ScaleType::Diatonic, Mode::Ionian),
             (
                 "Bb Harmonic Minor",
-                pitch(B, -1),
+                Pitch::new(B, -1),
                 ScaleType::HarmonicMinor,
                 Mode::HarmonicMinor,
             ),
             (
                 "Ds Melodic Minor",
-                pitch(D, 1),
+                Pitch::new(D, 1),
                 ScaleType::MelodicMinor,
                 Mode::MelodicMinor,
             ),

--- a/tests/scale/test_regex.rs
+++ b/tests/scale/test_regex.rs
@@ -1,5 +1,5 @@
 extern crate rust_music_theory as theory;
-use theory::note::PitchClass::*;
+use theory::note::{NoteLetter::*, pitch};
 use theory::scale::{Mode, Scale, ScaleType};
 
 #[cfg(test)]
@@ -9,26 +9,26 @@ mod chord_regex_tests {
     #[test]
     fn test_all_scales() {
         let table = vec![
-            ("C Major", C, ScaleType::Diatonic, Mode::Ionian),
-            ("CM", C, ScaleType::Diatonic, Mode::Ionian),
-            ("C Maj", C, ScaleType::Diatonic, Mode::Ionian),
-            ("C MAJOR", C, ScaleType::Diatonic, Mode::Ionian),
-            ("As locrian", As, ScaleType::Diatonic, Mode::Locrian),
-            ("Bs phrygian", C, ScaleType::Diatonic, Mode::Phrygian),
-            ("E lydian", E, ScaleType::Diatonic, Mode::Lydian),
-            ("F dorian", F, ScaleType::Diatonic, Mode::Dorian),
-            ("Gb mixolydian", Fs, ScaleType::Diatonic, Mode::Mixolydian),
-            ("B MAJOR", B, ScaleType::Diatonic, Mode::Ionian),
-            ("Bb MAJOR", As, ScaleType::Diatonic, Mode::Ionian),
+            ("C Major", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("CM", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("C Maj", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("C MAJOR", pitch(C, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("As locrian", pitch(A, 1), ScaleType::Diatonic, Mode::Locrian),
+            ("Bs phrygian", pitch(B, 1), ScaleType::Diatonic, Mode::Phrygian),
+            ("E lydian", pitch(E, 0), ScaleType::Diatonic, Mode::Lydian),
+            ("F dorian", pitch(F, 0), ScaleType::Diatonic, Mode::Dorian),
+            ("Gb mixolydian", pitch(G, -1), ScaleType::Diatonic, Mode::Mixolydian),
+            ("B MAJOR", pitch(B, 0), ScaleType::Diatonic, Mode::Ionian),
+            ("Bb MAJOR", pitch(B, -1), ScaleType::Diatonic, Mode::Ionian),
             (
                 "Bb Harmonic Minor",
-                As,
+                pitch(B, -1),
                 ScaleType::HarmonicMinor,
                 Mode::HarmonicMinor,
             ),
             (
                 "Ds Melodic Minor",
-                Ds,
+                pitch(D, 1),
                 ScaleType::MelodicMinor,
                 Mode::MelodicMinor,
             ),

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -56,7 +56,7 @@ mod scale_tests {
     fn test_octave_increment() {
         let scale = Scale::new(
             ScaleType::Diatonic,
-            pitch(NoteLetter::G, 0),
+            Pitch::new(NoteLetter::G, 0),
             5,
             Some(Mode::Mixolydian),
             Direction::Ascending,

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -35,11 +35,11 @@ mod scale_tests {
         for (scale_tuple, pitches) in scale_tuples.iter() {
             let (scale_type, mode) = scale_tuple;
             let scale_ascending =
-                Scale::new(*scale_type, C, 4, *mode, Direction::Ascending).unwrap();
+                Scale::new(*scale_type, Pitch::from(C), 4, *mode, Direction::Ascending).unwrap();
             assert_notes(pitches, scale_ascending.notes());
 
             let scale_descending =
-                Scale::new(*scale_type, C, 4, *mode, Direction::Descending).unwrap();
+                Scale::new(*scale_type, Pitch::from(C), 4, *mode, Direction::Descending).unwrap();
             let mut pitches_descending = pitches.clone();
             pitches_descending.reverse();
             assert_notes(&pitches_descending, scale_descending.notes());

--- a/tests/scale/test_scale.rs
+++ b/tests/scale/test_scale.rs
@@ -1,10 +1,10 @@
 extern crate rust_music_theory as theory;
-use theory::note::{PitchClass::*, *};
+use theory::note::{PitchSymbol::*, *};
 use theory::scale::{Mode::*, ScaleType::*, *};
 
-fn assert_notes(pitches: &[PitchClass], notes: Vec<Note>) {
-    for (i, pitch) in pitches.iter().enumerate() {
-        assert_eq!(*pitch, notes[i].pitch_class);
+fn assert_notes(symbols: &[PitchSymbol], notes: Vec<Note>) {
+    for (i, symbol) in symbols.iter().enumerate() {
+        assert_eq!(Pitch::from(*symbol), notes[i].pitch);
     }
 }
 
@@ -29,7 +29,7 @@ mod scale_tests {
             (
                 (ScaleType::MelodicMinor, None),
                 vec![C, D, Ds, F, G, A, B, C],
-            ),
+            )
         ];
 
         for (scale_tuple, pitches) in scale_tuples.iter() {
@@ -56,7 +56,7 @@ mod scale_tests {
     fn test_octave_increment() {
         let scale = Scale::new(
             ScaleType::Diatonic,
-            PitchClass::G,
+            pitch(NoteLetter::G, 0),
             5,
             Some(Mode::Mixolydian),
             Direction::Ascending,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,7 +11,7 @@ mod scale {
 }
 
 mod note {
-    mod test_pitch_class;
+    mod test_pitch;
 }
 
 mod interval {


### PR DESCRIPTION
## Original PR is #15 by @jagen31

On top of #15, this PR:
- Resolves the merge with master
- Renames structs in accordance with music theory conventions
- Added some abstractions to reduce and simplify code

## Changes from `master`
- Several renames produce this new scheme:
    - `NoteLetter`: A, B, C, etc. Just the letters of the white keys on a piano
    - `Pitch`: A note letter and an accidental
        - New related abstraction `PitchSymbol`, an enum { Cb, C, Cs, Db...} convertible to Pitch for code brevity
    - `Note` wraps a `Pitch` with an octave
- More extensive accidental support in parsing, including double sharps/flats in format

## Some notes going forward (pun intended)
- `Cb` breaks everything as a result of the current design of integer conversions
    - If `C4` is flatted, does it produce `Cb4` or `Cb3`. It's enharmonic to `B3` but relative to `C`. Either solution brings up some dependency questions.
- Some extra considerations will be necessary for double flats and sharps to work throughout the library
- The above two can be fixed alongside enharmonic support, which I'll be happy to tackle next

@ozankasikci tests run perfectly, but the actual test code and style consistency could use a good lookover